### PR TITLE
chore(deps): update dependencies react-scripts, webpack, and testcafe

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "react-router": "5.1.2",
     "react-router-dom": "5.1.2",
     "react-router-transition": "2.0.0",
-    "react-scripts": "3.1.2",
+    "react-scripts": "3.2.0",
     "redux": "4.0.4",
     "redux-logger": "3.0.6",
     "standard-version": "7.0.0",
@@ -128,13 +128,13 @@
     "stylelint": "11.1.1",
     "stylelint-config-prettier": "6.0.0",
     "stylelint-config-standard": "19.0.0",
-    "testcafe": "1.6.0",
+    "testcafe": "1.6.1-alpha.2",
     "testcafe-browser-provider-electron": "0.0.12",
     "testcafe-react-selectors": "3.3.0",
     "ts-node": "8.4.1",
     "typescript": "3.6.4",
     "wait-on": "3.3.0",
-    "webpack": "4.40.2"
+    "webpack": "4.41.0"
   },
   "husky": {
     "hooks": {

--- a/src/components/designer/NetworkDesigner.spec.tsx
+++ b/src/components/designer/NetworkDesigner.spec.tsx
@@ -33,61 +33,54 @@ describe('NetworkDesigner Component', () => {
     return renderWithProviders(cmp, { initialState });
   };
 
-  it('should render the designer component', async () => {
+  it('should render the designer component', () => {
     const { getByText } = renderComponent();
     expect(getByText('lnd-1')).toBeInTheDocument();
     expect(getByText('lnd-2')).toBeInTheDocument();
     expect(getByText('bitcoind-1')).toBeInTheDocument();
   });
 
-  it('should render correct # of LND nodes', () => {
-    const { queryAllByText } = renderComponent();
-    expect(queryAllByText(/lnd-\d/)).toHaveLength(2);
+  it('should render correct # of LND nodes', async () => {
+    const { findAllByText } = renderComponent();
+    expect(await findAllByText(/lnd-\d/)).toHaveLength(2);
   });
 
-  it('should render correct # of bitcoind nodes', () => {
-    const { queryAllByText } = renderComponent();
-    expect(queryAllByText(/bitcoind-\d/)).toHaveLength(1);
+  it('should render correct # of bitcoind nodes', async () => {
+    const { findAllByText } = renderComponent();
+    expect(await findAllByText(/bitcoind-\d/)).toHaveLength(1);
   });
 
-  it('should display the default message in the sidebar', () => {
-    const { getByText } = renderComponent();
-    expect(getByText('Network Designer')).toBeInTheDocument();
+  it('should display the default message in the sidebar', async () => {
+    const { findByText } = renderComponent();
+    expect(await findByText('Network Designer')).toBeInTheDocument();
   });
 
   it('should update the redux state after a node is selected', async () => {
     const { getByText, store } = renderComponent();
     expect(store.getState().designer.activeChart.selected.id).toBeFalsy();
-    fireEvent.click(getByText('lnd-1'));
-
-    await wait(() => {
-      expect(store.getState().designer.activeChart.selected.id).not.toBeUndefined();
-    });
+    await wait(() => fireEvent.click(getByText('lnd-1')));
+    expect(store.getState().designer.activeChart.selected.id).not.toBeUndefined();
   });
 
   it('should not set the active chart if it doesnt exist', async () => {
     const { getByLabelText, store } = renderComponent({});
-    await wait(() => {
-      expect(store.getState().designer.activeChart).toBeUndefined();
-      expect(getByLabelText('icon: loading')).toBeInTheDocument();
-    });
+    expect(store.getState().designer.activeChart).toBeUndefined();
+    expect(getByLabelText('icon: loading')).toBeInTheDocument();
   });
 
   it('should display node details in the sidebar when a node is selected', async () => {
-    const { getByText, queryByText, findByText } = renderComponent();
+    const { getByText, queryByText } = renderComponent();
     expect(getByText('bitcoind-1')).toBeInTheDocument();
     expect(queryByText('Node Type')).not.toBeInTheDocument();
     // click the bitcoind node in the chart
-    fireEvent.click(getByText('bitcoind-1'));
+    await wait(() => fireEvent.click(getByText('bitcoind-1')));
     // ensure text from the sidebar is visible
-    expect(await findByText('Node Type')).toBeInTheDocument();
+    expect(getByText('Node Type')).toBeInTheDocument();
   });
 
   it('should display the OpenChannel modal', async () => {
     const { getByText, store } = renderComponent();
-    await wait(() => {
-      store.getActions().modals.showOpenChannel({});
-      expect(getByText('Capacity (sats)')).toBeInTheDocument();
-    });
+    await wait(() => store.getActions().modals.showOpenChannel({}));
+    expect(getByText('Capacity (sats)')).toBeInTheDocument();
   });
 });

--- a/src/components/designer/bitcoind/MineBlocksInput.spec.tsx
+++ b/src/components/designer/bitcoind/MineBlocksInput.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent } from '@testing-library/dom';
+import { fireEvent, waitForDomChange } from '@testing-library/dom';
 import { getNetwork, injections, renderWithProviders } from 'utils/tests';
 import MineBlocksInput from './MineBlocksInput';
 
@@ -42,13 +42,14 @@ describe('MineBlocksInput', () => {
     expect(input.value).toEqual('6');
   });
 
-  it('should mine a block when the button is clicked', () => {
+  it('should mine a block when the button is clicked', async () => {
     const mineMock = injections.bitcoindService.mine as jest.Mock;
     mineMock.mockResolvedValue(true);
     const { input, btn, store } = renderComponent();
     const numBlocks = 5;
     fireEvent.change(input, { target: { value: numBlocks } });
     fireEvent.click(btn);
+    await waitForDomChange();
     const port = store.getState().network.networks[0].nodes.bitcoin[0].ports.rpc;
     expect(mineMock).toBeCalledWith(numBlocks, port);
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4873,7 +4873,7 @@ chai@^4.1.2:
     pathval "^1.1.0"
     type-detect "^4.0.5"
 
-chalk@2.4.2, chalk@^2.4.0, chalk@^2.4.2:
+chalk@2.4.2, chalk@^2.3.0, chalk@^2.4.0, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -4882,7 +4882,7 @@ chalk@2.4.2, chalk@^2.4.0, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.3:
+chalk@^1.0.0, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   integrity sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=
@@ -7339,15 +7339,16 @@ eslint-import-resolver-node@^0.3.2:
     debug "^2.6.9"
     resolve "^1.5.0"
 
-eslint-loader@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-loader/-/eslint-loader-3.0.0.tgz#fb70bc2d552a674f43f07f5e6575083e565e790d"
-  integrity sha512-rdxyQ0i9VlhwVlR6oEzrIft8WNKYSD2/cOAJ1YVH/F76gAta7Zv1Dr5xJOUyx0fAsHB5cKNz9hwlUVLMFsQlPA==
+eslint-loader@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/eslint-loader/-/eslint-loader-3.0.2.tgz#5a627316a51d6f41d357b9f6f0554e91506cdd6e"
+  integrity sha512-S5VnD+UpVY1PyYRqeBd/4pgsmkvSokbHqTXAQMpvCyRr3XN2tvSLo9spm2nEpqQqh9dezw3os/0zWihLeOg2Rw==
   dependencies:
+    fs-extra "^8.1.0"
     loader-fs-cache "^1.0.2"
     loader-utils "^1.2.3"
     object-hash "^1.3.1"
-    schema-utils "^2.1.0"
+    schema-utils "^2.2.0"
 
 eslint-module-utils@^2.4.0:
   version "2.4.1"
@@ -9764,10 +9765,10 @@ is-directory@^0.3.1:
   resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
   integrity sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=
 
-is-docker@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-1.1.0.tgz#f04374d4eee5310e9a8e113bf1495411e46176a1"
-  integrity sha1-8EN01O7lMQ6ajhE78UlUEeRhdqE=
+is-docker@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.0.0.tgz#2cb0df0e75e2d064fe1864c37cdeacb7b2dcf25b"
+  integrity sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ==
 
 is-es2016-keyword@^1.0.0:
   version "1.0.0"
@@ -11500,7 +11501,7 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
-make-dir@^1.0.0, make-dir@^1.3.0:
+make-dir@^1.0.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.3.0.tgz#79c1033b80515bd6d24ec9933e860ca75ee27f0c"
   integrity sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==
@@ -11514,6 +11515,13 @@ make-dir@^2.0.0, make-dir@^2.1.0:
   dependencies:
     pify "^4.0.1"
     semver "^5.6.0"
+
+make-dir@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.0.0.tgz#1b5f39f6b9270ed33f9f054c5c0f84304989f801"
+  integrity sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==
+  dependencies:
+    semver "^6.0.0"
 
 make-error@^1.1.1:
   version "1.3.5"
@@ -14904,10 +14912,10 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.1, rc@^1.2.7, rc@^1.2.8:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-app-polyfill@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/react-app-polyfill/-/react-app-polyfill-1.0.3.tgz#bd7030ebf66569f3aece03e39ab85ca700d8d0f6"
-  integrity sha512-ICvAU2vtO0k+kU0oCS7L7btUcAReTddvEiRiJDmAKc+d98Fy9Z1g6cjkdcKyfLWwopzBsUMcDwxoiNtrtLMs0Q==
+react-app-polyfill@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/react-app-polyfill/-/react-app-polyfill-1.0.4.tgz#4dd2636846b585c2d842b1e44e1bc29044345874"
+  integrity sha512-5Vte6ki7jpNsNCUKaboyofAhmURmCn2Y6Hu7ydJ6Iu4dct1CIGoh/1FT7gUZKAbowVX2lxVPlijvp1nKxfAl4w==
   dependencies:
     core-js "3.2.1"
     object-assign "4.1.1"
@@ -14959,10 +14967,10 @@ react-dev-utils@^7.0.0:
     strip-ansi "5.0.0"
     text-table "0.2.0"
 
-react-dev-utils@^9.0.4:
-  version "9.0.4"
-  resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-9.0.4.tgz#5c71a8e8afdec0232c44d4e049d21baa437a92af"
-  integrity sha512-VwR+mBUXPLdYk/rOz6s6qpasIFGd7GW0KXd/3bih+/qGcMQvPG19XxtjDMtiAg0zWiFwp1ugCzAjLThbzFjVqw==
+react-dev-utils@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-9.1.0.tgz#3ad2bb8848a32319d760d0a84c56c14bdaae5e81"
+  integrity sha512-X2KYF/lIGyGwP/F/oXgGDF24nxDA2KC4b7AFto+eqzc/t838gpSGiaU8trTqHXOohuLxxc5qi1eDzsl9ucPDpg==
   dependencies:
     "@babel/code-frame" "7.5.5"
     address "1.1.2"
@@ -14983,7 +14991,7 @@ react-dev-utils@^9.0.4:
     loader-utils "1.2.3"
     open "^6.3.0"
     pkg-up "2.0.0"
-    react-error-overlay "^6.0.2"
+    react-error-overlay "^6.0.3"
     recursive-readdir "2.2.2"
     shell-quote "1.7.2"
     sockjs-client "1.4.0"
@@ -15013,10 +15021,10 @@ react-error-overlay@^5.1.4:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-5.1.6.tgz#0cd73407c5d141f9638ae1e0c63e7b2bf7e9929d"
   integrity sha512-X1Y+0jR47ImDVr54Ab6V9eGk0Hnu7fVWGeHQSOXHf/C2pF9c6uy3gef8QUeuUiWlNb0i08InPSE5a/KJzNzw1Q==
 
-react-error-overlay@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.2.tgz#642bd6157c6a4b6e9ca4a816f7ed30b868c47f81"
-  integrity sha512-DHRuRk3K4Lg9obI6J4Y+nKvtwjasYRU9CFL3ud42x9YJG1HbQjSNublapC/WBJOA726gNUbqbj0U2df9+uzspQ==
+react-error-overlay@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.3.tgz#c378c4b0a21e88b2e159a3e62b2f531fd63bf60d"
+  integrity sha512-bOUvMWFQVk5oz8Ded9Xb7WVdEi3QGLC8tH7HmYP0Fdp4Bn3qw0tRFmr5TW6mvahzvmrK4a6bqWGfCevBflP+Xw==
 
 react-hot-loader@4.12.15:
   version "4.12.15"
@@ -15128,10 +15136,10 @@ react-router@5.1.2:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react-scripts@3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/react-scripts/-/react-scripts-3.1.2.tgz#40b166d380bfd8b425a41dee96e8e725c82bf9e6"
-  integrity sha512-aN9E1jn+Qii45/uLUzS7Hjfd/DXbcaAiRkoMwnJXAXShbpJiP2xwmr7yuVF0kR0cnvt0SI+IPZjsOH8MziSYQQ==
+react-scripts@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-scripts/-/react-scripts-3.2.0.tgz#58ccd6b4ffa27f1b4d2986cbdcaa916660e9e33c"
+  integrity sha512-6LzuKbE2B4eFQG6i1FnTScn9HDcWBfXXnOwW9xKFPJ/E3rK8i1ufbOZ0ocKyRPxJAKdN7iqg3i7lt0+oxkSVOA==
   dependencies:
     "@babel/core" "7.6.0"
     "@svgr/webpack" "4.3.2"
@@ -15149,7 +15157,7 @@ react-scripts@3.1.2:
     dotenv-expand "5.1.0"
     eslint "^6.1.0"
     eslint-config-react-app "^5.0.2"
-    eslint-loader "3.0.0"
+    eslint-loader "3.0.2"
     eslint-plugin-flowtype "3.13.0"
     eslint-plugin-import "2.18.2"
     eslint-plugin-jsx-a11y "6.2.3"
@@ -15172,8 +15180,8 @@ react-scripts@3.1.2:
     postcss-normalize "7.0.1"
     postcss-preset-env "6.7.0"
     postcss-safe-parser "4.0.1"
-    react-app-polyfill "^1.0.3"
-    react-dev-utils "^9.0.4"
+    react-app-polyfill "^1.0.4"
+    react-dev-utils "^9.1.0"
     resolve "1.12.0"
     resolve-url-loader "3.1.0"
     sass-loader "7.2.0"
@@ -15182,9 +15190,9 @@ react-scripts@3.1.2:
     terser-webpack-plugin "1.4.1"
     ts-pnp "1.1.4"
     url-loader "2.1.0"
-    webpack "4.40.2"
+    webpack "4.41.0"
     webpack-dev-server "3.2.1"
-    webpack-manifest-plugin "2.0.4"
+    webpack-manifest-plugin "2.1.1"
     workbox-webpack-plugin "4.3.1"
   optionalDependencies:
     fsevents "2.0.7"
@@ -16142,10 +16150,10 @@ schema-utils@^2.0.0, schema-utils@^2.0.1:
     ajv "^6.1.0"
     ajv-keywords "^3.1.0"
 
-schema-utils@^2.1.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.2.0.tgz#48a065ce219e0cacf4631473159037b2c1ae82da"
-  integrity sha512-5EwsCNhfFTZvUreQhx/4vVQpJ/lnCAkgoIHLhSpp4ZirE+4hzFvdJi0FMub6hxbFVBJYSpeVVmon+2e7uEGRrA==
+schema-utils@^2.2.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.5.0.tgz#8f254f618d402cc80257486213c8970edfd7c22f"
+  integrity sha512-32ISrwW2scPXHUSusP8qMg5dLUawKkyV+/qIEV9JdXKx+rsM6mi8vZY8khg2M69Qom16rtroWXD3Ybtiws38gQ==
   dependencies:
     ajv "^6.10.2"
     ajv-keywords "^3.4.1"
@@ -17393,10 +17401,10 @@ testcafe-browser-provider-electron@0.0.12:
     promisify-event "^1.0.0"
     proxyquire "^1.7.10"
 
-testcafe-browser-tools@1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/testcafe-browser-tools/-/testcafe-browser-tools-1.7.0.tgz#62ca15c0e64e1c49e110fea1b1b1d8b115343f2b"
-  integrity sha512-85CabhVhxrVriOCqwm5rGLA5LQ/tzuMYhPPmLE0eZhHHHX+qh1a8vbDfwJIn2TFgX0bNq9ZmCPV8RQfU8P0UAQ==
+testcafe-browser-tools@1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/testcafe-browser-tools/-/testcafe-browser-tools-1.7.1.tgz#675951da859dbc17bfe6beed1040b6b26fe039cb"
+  integrity sha512-9Lf4MAmVrxbdP5PiwO2PpLGF3aOXWzlaxVDEDfO2p4orfJNiQ8eTZMMqWWPXDxE/5CqDq/h9xBXjvZo+1cW5ew==
   dependencies:
     array-find "^1.0.0"
     babel-runtime "^5.6.15"
@@ -17412,10 +17420,10 @@ testcafe-browser-tools@1.7.0:
     read-file-relative "^1.2.0"
     which-promise "^1.0.0"
 
-testcafe-hammerhead@14.9.2:
-  version "14.9.2"
-  resolved "https://registry.yarnpkg.com/testcafe-hammerhead/-/testcafe-hammerhead-14.9.2.tgz#5ab3f32a08d994f189885f4bf648d9bbe90f9be2"
-  integrity sha512-0rO9NTTueDXPqeWASThKEHX5AGF0FDhiPVRdkkWnKUOAtfPJz/qovZnIEpoC7q0DdmgbYYvK3if9Si8SdFNk0A==
+testcafe-hammerhead@14.10.2:
+  version "14.10.2"
+  resolved "https://registry.yarnpkg.com/testcafe-hammerhead/-/testcafe-hammerhead-14.10.2.tgz#5eb87b8b3481c4cb53a999c104efccc808510716"
+  integrity sha512-6xxaVU4vO9wHXFpDdyDWVnU1fuDMkvSjuYpKzjrsoA8kNc+zA9T35AMT7EI+pyh7amteJRtsD0jnRU+ASeAfdQ==
   dependencies:
     acorn-hammerhead "^0.3.0"
     asar "^2.0.1"
@@ -17490,10 +17498,10 @@ testcafe-reporter-xunit@^2.1.0:
   resolved "https://registry.yarnpkg.com/testcafe-reporter-xunit/-/testcafe-reporter-xunit-2.1.0.tgz#e6d66c572ce15af266706af0fd610b2a841dd443"
   integrity sha1-5tZsVyzhWvJmcGrw/WELKoQd1EM=
 
-testcafe@1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/testcafe/-/testcafe-1.6.0.tgz#94313af0dfaf384d9e05ee0409d90fa56facebc3"
-  integrity sha512-jlydNbQ6m/LdM6o40EzDwMXBKWV8evZV2Xa1YzzJ9r6H58Y4FHpeYjDtv5gDaBkpV7NslDFXoOkpwnZgRvAjcw==
+testcafe@1.6.1-alpha.2:
+  version "1.6.1-alpha.2"
+  resolved "https://registry.yarnpkg.com/testcafe/-/testcafe-1.6.1-alpha.2.tgz#17bef322d8414a676e25d74c06a8ea6296af179e"
+  integrity sha512-SdqfjyoDGWBUXUXaChcsfaFZ/1aboKx0B0HcRa7soVpea1HT04Sq47DMV4CKzFgksmjqmxTzb9Z44D72zBPAtw==
   dependencies:
     "@types/node" "^10.12.19"
     async-exit-hook "^1.1.2"
@@ -17509,7 +17517,7 @@ testcafe@1.6.0:
     callsite "^1.0.0"
     callsite-record "^4.0.0"
     chai "^4.1.2"
-    chalk "^1.1.0"
+    chalk "^2.3.0"
     chrome-emulated-devices-list "^0.1.0"
     chrome-remote-interface "^0.25.3"
     coffeescript "^2.3.1"
@@ -17527,13 +17535,13 @@ testcafe@1.6.0:
     import-lazy "^3.1.0"
     indent-string "^1.2.2"
     is-ci "^1.0.10"
-    is-docker "^1.1.0"
+    is-docker "^2.0.0"
     is-glob "^2.0.1"
     is-stream "^1.1.0"
     json5 "^2.1.0"
     lodash "^4.17.13"
     log-update-async-hook "^2.0.2"
-    make-dir "^1.3.0"
+    make-dir "^3.0.0"
     map-reverse "^1.0.1"
     mime-db "^1.41.0"
     moment "^2.10.3"
@@ -17555,8 +17563,8 @@ testcafe@1.6.0:
     sanitize-filename "^1.6.0"
     source-map-support "^0.5.5"
     strip-bom "^2.0.0"
-    testcafe-browser-tools "1.7.0"
-    testcafe-hammerhead "14.9.2"
+    testcafe-browser-tools "1.7.1"
+    testcafe-hammerhead "14.10.2"
     testcafe-legacy-api "3.1.11"
     testcafe-reporter-json "^2.1.0"
     testcafe-reporter-list "^2.1.0"
@@ -18612,13 +18620,14 @@ webpack-log@^2.0.0:
     ansi-colors "^3.0.0"
     uuid "^3.3.2"
 
-webpack-manifest-plugin@2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/webpack-manifest-plugin/-/webpack-manifest-plugin-2.0.4.tgz#e4ca2999b09557716b8ba4475fb79fab5986f0cd"
-  integrity sha512-nejhOHexXDBKQOj/5v5IZSfCeTO3x1Dt1RZEcGfBSul891X/eLIcIVH31gwxPDdsi2Z8LKKFGpM4w9+oTBOSCg==
+webpack-manifest-plugin@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/webpack-manifest-plugin/-/webpack-manifest-plugin-2.1.1.tgz#6b3e280327815b83152c79f42d0ca13b665773c4"
+  integrity sha512-2zqJ6mvc3yoiqfDjghAIpljhLSDh/G7vqGrzYcYqqRCd/ZZZCAuc/YPE5xG0LGpLgDJRhUNV1H+znyyhIxahzA==
   dependencies:
     fs-extra "^7.0.0"
     lodash ">=3.5 <5"
+    object.entries "^1.1.0"
     tapable "^1.0.0"
 
 webpack-sources@^1.1.0:
@@ -18637,10 +18646,10 @@ webpack-sources@^1.4.0, webpack-sources@^1.4.1:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@4.40.2:
-  version "4.40.2"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.40.2.tgz#d21433d250f900bf0facbabe8f50d585b2dc30a7"
-  integrity sha512-5nIvteTDCUws2DVvP9Qe+JPla7kWPPIDFZv55To7IycHWZ+Z5qBdaBYPyuXWdhggTufZkQwfIK+5rKQTVovm2A==
+webpack@4.41.0:
+  version "4.41.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.41.0.tgz#db6a254bde671769f7c14e90a1a55e73602fc70b"
+  integrity sha512-yNV98U4r7wX1VJAj5kyMsu36T8RPPQntcb5fJLOsMz/pt/WrKC0Vp1bAlqPLkA1LegSwQwf6P+kAbyhRKVQ72g==
   dependencies:
     "@webassemblyjs/ast" "1.8.5"
     "@webassemblyjs/helper-module-context" "1.8.5"


### PR DESCRIPTION
These dependency updates must be made altogether because the version of webpack used by this project must match the version used by react-scripts. The renovate bot doesn't know how to do them both at the same time. testcafe needed to also be updated due to a [bug](https://github.com/DevExpress/testcafe/issues/4435).