### PR TITLE
feat(network): display slow start notice if docker images need to be pulled

### DIFF
--- a/src/components/network/NetworkView.tsx
+++ b/src/components/network/NetworkView.tsx
@@ -147,16 +147,14 @@ const NetworkView: React.FC<RouteComponentProps<MatchParams>> = ({ match }) => {
   }
 
   const missingImages = getMissingImages(network, dockerImages);
-  const showWarning =
+  const showNotice =
     [Status.Stopped, Status.Starting].includes(network.status) &&
     missingImages.length > 0;
 
   return (
     <Styled.NetworkView>
       {header}
-      {showWarning && (
-        <Styled.Alert type="warning" message={l('missingImages')} showIcon />
-      )}
+      {showNotice && <Styled.Alert type="info" message={l('missingImages')} showIcon />}
       {toggleAsync.error && (
         <Styled.Alert
           type="error"

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -128,6 +128,7 @@
   "cmps.network.NetworkActions.primaryBtnRestart": "Restart",
   "cmps.network.NetworkActions.mineBtn": "Quick Mine",
   "cmps.network.NetworkActions.mineError": "Unable to mine blocks",
+  "cmps.network.NetworkView.missingImages": "Starting this network will take a bit longer than normal because it uses docker images that have not been downloaded yet.",
   "cmps.network.NetworkView.renameSave": "Save",
   "cmps.network.NetworkView.renameCancel": "Cancel",
   "cmps.network.NetworkView.renameError": "Failed to rename the network",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -128,6 +128,7 @@
   "cmps.network.NetworkActions.primaryBtnRestart": "Reiniciar",
   "cmps.network.NetworkActions.mineBtn": "Mina rápida",
   "cmps.network.NetworkActions.mineError": "Incapaz de extraer bloques",
+  "cmps.network.NetworkView.missingImages": "Iniciar esta red tomará un poco más de tiempo de lo normal porque usa imágenes acopladas que aún no se han descargado.",
   "cmps.network.NetworkView.renameSave": "Salvar",
   "cmps.network.NetworkView.renameCancel": "Cancelar",
   "cmps.network.NetworkView.renameError": "Error al cambiar el nombre de la red",

--- a/src/store/models/app.ts
+++ b/src/store/models/app.ts
@@ -15,10 +15,13 @@ export interface NotifyOptions {
 export interface AppModel {
   initialized: boolean;
   dockerVersions: DockerVersions;
+  dockerImages: string[];
   setInitialized: Action<AppModel, boolean>;
   initialize: Thunk<AppModel, any, StoreInjections, RootModel>;
   setDockerVersions: Action<AppModel, DockerVersions>;
   getDockerVersions: Thunk<AppModel, { throwErr?: boolean }, StoreInjections, RootModel>;
+  setDockerImages: Action<AppModel, string[]>;
+  getDockerImages: Thunk<AppModel, any, StoreInjections, RootModel>;
   notify: Action<AppModel, NotifyOptions>;
   navigateTo: Thunk<AppModel, string>;
   openInBrowser: Action<AppModel, string>;
@@ -27,10 +30,8 @@ export interface AppModel {
 const appModel: AppModel = {
   // state properties
   initialized: false,
-  dockerVersions: {
-    docker: '',
-    compose: '',
-  },
+  dockerVersions: { docker: '', compose: '' },
+  dockerImages: [],
   // reducer actions (mutations allowed thx to immer)
   setInitialized: action((state, initialized) => {
     state.initialized = initialized;
@@ -38,6 +39,7 @@ const appModel: AppModel = {
   initialize: thunk(async (actions, payload, { getStoreActions }) => {
     await getStoreActions().network.load();
     await actions.getDockerVersions({});
+    await actions.getDockerImages();
     actions.setInitialized(true);
   }),
   setDockerVersions: action((state, versions) => {
@@ -46,6 +48,13 @@ const appModel: AppModel = {
   getDockerVersions: thunk(async (actions, { throwErr }, { injections }) => {
     const versions = await injections.dockerService.getVersions(throwErr);
     actions.setDockerVersions(versions);
+  }),
+  setDockerImages: action((state, images) => {
+    state.dockerImages = images;
+  }),
+  getDockerImages: thunk(async (actions, payload, { injections }) => {
+    const images = await injections.dockerService.getImages();
+    actions.setDockerImages(images);
   }),
   notify: action((state, { message, description, error }) => {
     const options = {

--- a/src/store/models/network.spec.ts
+++ b/src/store/models/network.spec.ts
@@ -5,6 +5,7 @@ import { Network } from 'types';
 import { initChartFromNetwork } from 'utils/chart';
 import * as files from 'utils/files';
 import { getNetwork, injections } from 'utils/tests';
+import appModel from './app';
 import bitcoindModel from './bitcoind';
 import designerModel from './designer';
 import lndModel from './lnd';
@@ -22,6 +23,7 @@ const bitcoindServiceMock = injections.bitcoindService as jest.Mocked<
 
 describe('Network model', () => {
   const rootModel = {
+    app: appModel,
     network: networkModel,
     lnd: lndModel,
     bitcoind: bitcoindModel,

--- a/src/store/models/network.ts
+++ b/src/store/models/network.ts
@@ -125,7 +125,7 @@ const networkModel: NetworkModel = {
     if (!network) throw new Error(l('networkByIdErr', { networkId: id }));
     const node = createLndNetworkNode(network, version, Status.Stopped);
     network.nodes.lightning.push(node);
-    actions.setNetworks(networks);
+    actions.setNetworks([...networks]);
     await actions.save();
     await injections.dockerService.saveComposeFile(network);
     return node;
@@ -169,6 +169,8 @@ const networkModel: NetworkModel = {
       }
       // start the docker containers
       await injections.dockerService.start(network);
+      // update the list of docker images pulled since new images may be pulled
+      await getStoreActions().app.getDockerImages();
       // set the status of only the network to Started
       actions.setStatus({ id, status: Status.Started, all: false });
       // wait for lnd nodes to come online before updating their status

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -28,6 +28,7 @@ export interface DockerVersions {
 
 export interface DockerLibrary {
   getVersions: (throwOnError?: boolean) => Promise<DockerVersions>;
+  getImages: () => Promise<string[]>;
   saveComposeFile: (network: Network) => Promise<void>;
   start: (network: Network) => Promise<void>;
   stop: (network: Network) => Promise<void>;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,3 +1,6 @@
+// Docker
+export const DOCKER_REPO = 'polarlightning';
+
 // bitcoind
 export const BLOCKS_TIL_COMFIRMED = 6;
 export const COINBASE_MATURITY_HEIGHT = 100;

--- a/src/utils/network.ts
+++ b/src/utils/network.ts
@@ -105,6 +105,23 @@ export const createNetwork = (config: {
 };
 
 /**
+ * Returns the images needed to start a network that are not included in the list
+ * of images already pulled
+ * @param network the network to check
+ * @param pulled the list of images already pulled
+ */
+export const getMissingImages = (network: Network, pulled: string[]): string[] => {
+  const { bitcoin, lightning } = network.nodes;
+  const neededImages = [...bitcoin, ...lightning].map(
+    n => `${n.implementation.toLocaleLowerCase()}:${n.version}`,
+  );
+  // exclude images already pulled
+  const missing = neededImages.filter(i => !pulled.includes(i));
+  // filter out duplicates
+  return missing.filter((image, index) => missing.indexOf(image) === index);
+};
+
+/**
  * Checks a range of port numbers to see if they are open on the current operating system.
  * Returns a new array of port numbers that are confirmed available
  * @param requestedPorts the ports to check for availability. ** must be in ascending order

--- a/src/utils/tests.tsx
+++ b/src/utils/tests.tsx
@@ -29,6 +29,7 @@ export const mockProperty = <T extends {}, K extends keyof T>(
 export const injections: StoreInjections = {
   dockerService: {
     getVersions: jest.fn(),
+    getImages: jest.fn(),
     saveComposeFile: jest.fn(),
     start: jest.fn(),
     stop: jest.fn(),


### PR DESCRIPTION
### Description

Displays a banner when the docker images needed to start a network have not been downloaded yet.

### Screenshots

<img width="1344" alt="Screen Shot 2019-11-01 at 12 10 28 PM" src="https://user-images.githubusercontent.com/1356600/68038576-a681c480-fca0-11e9-92ec-96fa21134b92.png">

