### PR TITLE
fix(docker): fix containers not starting up on linux

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -14,7 +14,7 @@ _Warning: These images are not hardened and shouldn't be used to store real bitc
 
 ```sh
 $ cd bitcoind
-$ docker build --build-arg BITCOIN_VERSION=<version> -t polarlightning/bitcoind:<version> .
+$ docker build --build-arg BITCOIN_VERSION=<version> -t polarlightning/bitcoind:latest -t polarlightning/bitcoind:<version> .
 ```
 
 Replace `<version>` with the desired bitcoind version (ex: `0.18.1`)
@@ -23,6 +23,7 @@ Replace `<version>` with the desired bitcoind version (ex: `0.18.1`)
 
 ```sh
 $ docker push polarlightning/bitcoind:<version>
+$ docker push polarlightning/bitcoind:latest
 ```
 
 ## LND
@@ -36,7 +37,7 @@ $ docker push polarlightning/bitcoind:<version>
 
 ```sh
 $ cd lnd
-$ docker build --build-arg LND_VERSION=<version> -t polarlightning/lnd:<version> .
+$ docker build --build-arg LND_VERSION=<version> -t polarlightning/lnd:latest -t polarlightning/lnd:<version> .
 ```
 
 Replace `<version>` with the desired LND version (ex: `0.8.0-beta`)
@@ -45,4 +46,5 @@ Replace `<version>` with the desired LND version (ex: `0.8.0-beta`)
 
 ```sh
 $ docker push polarlightning/lnd:<version>
+$ docker push polarlightning/lnd:latest
 ```

--- a/docker/bitcoind/Dockerfile
+++ b/docker/bitcoind/Dockerfile
@@ -3,8 +3,7 @@ FROM debian:stable-slim
 ARG BITCOIN_VERSION
 ENV PATH=/opt/bitcoin-${BITCOIN_VERSION}/bin:$PATH
 
-RUN useradd -r bitcoin \
-  && apt-get update -y \
+RUN apt-get update -y \
   && apt-get install -y curl gosu \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
@@ -13,9 +12,9 @@ RUN curl -SLO https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${
   && tar -xzf *.tar.gz -C /opt \
   && rm *.tar.gz
 
-COPY --chown=bitcoin docker-entrypoint.sh /entrypoint.sh
+COPY docker-entrypoint.sh /entrypoint.sh
 
-RUN chmod +x /entrypoint.sh
+RUN chmod a+x /entrypoint.sh
 
 VOLUME ["/home/bitcoin/.bitcoin"]
 

--- a/docker/bitcoind/docker-entrypoint.sh
+++ b/docker/bitcoind/docker-entrypoint.sh
@@ -1,9 +1,15 @@
 #!/bin/sh
 set -e
 
+# containers on linux share file permissions with hosts.
+# assigning the same uid/gid from the host user
+# ensures that the files can be read/write from both sides
 if ! id bitcoin > /dev/null 2>&1; then
+  USERID=${USERID:-1000}
+  GROUPID=${GROUPID:-1000}
+
   echo "adding user bitcoin ($USERID:$GROUPID)"
-  groupadd -g $GROUPID bitcoin
+  groupadd -f -g $GROUPID bitcoin
   useradd -r -u $USERID -g $GROUPID bitcoin 
 fi
 
@@ -13,8 +19,8 @@ if [ $(echo "$1" | cut -c1) = "-" ]; then
   set -- bitcoind "$@"
 fi
 
-if [ "$1" = "bitcoind" ] || [ "$1" = "bitcoin-cli" ] || [ "$1" = "bitcoin-tx" ]; then
-  echo
+if [ "$1" = "bitcoind" ] || [ "$1" = "bitcoin-cli" ] || [ "$1" = "bitcoin-tx" ]; then 
+  echo "Running as bitcoin user: $@"
   exec gosu bitcoin "$@"
 fi
 

--- a/docker/bitcoind/docker-entrypoint.sh
+++ b/docker/bitcoind/docker-entrypoint.sh
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+if ! id bitcoin > /dev/null 2>&1; then
+  echo "adding user bitcoin ($USERID:$GROUPID)"
+  groupadd -g $GROUPID bitcoin
+  useradd -r -u $USERID -g $GROUPID bitcoin 
+fi
+
 if [ $(echo "$1" | cut -c1) = "-" ]; then
   echo "$0: assuming arguments for bitcoind"
 

--- a/docker/lnd/Dockerfile
+++ b/docker/lnd/Dockerfile
@@ -3,8 +3,7 @@ FROM debian:stable-slim
 ARG LND_VERSION
 ENV PATH=/opt/lnd-linux-amd64-v${LND_VERSION}:$PATH
 
-RUN useradd -r lnd \
-  && apt-get update -y \
+RUN apt-get update -y \
   && apt-get install -y curl gosu wait-for-it \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
@@ -13,9 +12,9 @@ RUN curl -SLO https://github.com/lightningnetwork/lnd/releases/download/v${LND_V
   && tar -xzf *.tar.gz -C /opt \
   && rm *.tar.gz
 
-COPY --chown=lnd docker-entrypoint.sh /entrypoint.sh
+COPY docker-entrypoint.sh /entrypoint.sh
 
-RUN chmod +x /entrypoint.sh
+RUN chmod a+x /entrypoint.sh
 
 VOLUME ["/home/lnd/.lnd"]
 

--- a/docker/lnd/docker-entrypoint.sh
+++ b/docker/lnd/docker-entrypoint.sh
@@ -1,9 +1,15 @@
 #!/bin/sh
 set -e
 
+# containers on linux share file permissions with hosts.
+# assigning the same uid/gid from the host user
+# ensures that the files can be read/write from both sides
 if ! id lnd > /dev/null 2>&1; then
+  USERID=${USERID:-1000}
+  GROUPID=${GROUPID:-1000}
+
   echo "adding user lnd ($USERID:$GROUPID)"
-  groupadd -g $GROUPID lnd
+  groupadd -f -g $GROUPID lnd
   useradd -r -u $USERID -g $GROUPID lnd 
 fi
 
@@ -14,7 +20,7 @@ if [ $(echo "$1" | cut -c1) = "-" ]; then
 fi
 
 if [ "$1" = "lnd" ] || [ "$1" = "lncli" ]; then
-  echo
+  echo "Running as lnd user: $@"
   exec gosu lnd "$@"
 fi
 

--- a/docker/lnd/docker-entrypoint.sh
+++ b/docker/lnd/docker-entrypoint.sh
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+if ! id lnd > /dev/null 2>&1; then
+  echo "adding user lnd ($USERID:$GROUPID)"
+  groupadd -g $GROUPID lnd
+  useradd -r -u $USERID -g $GROUPID lnd 
+fi
+
 if [ $(echo "$1" | cut -c1) = "-" ]; then
   echo "$0: assuming arguments for lnd"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polar",
-  "version": "0.0.2",
+  "version": "0.0.4",
   "homepage": "https://lightningpolar.com",
   "description": "One-click Bitcoin Lightning networks for local app development & testing",
   "author": {

--- a/src/__mocks__/fs-extra.js
+++ b/src/__mocks__/fs-extra.js
@@ -3,4 +3,5 @@ module.exports = {
   pathExists: jest.fn(),
   readFile: jest.fn(),
   remove: jest.fn(),
+  ensureDir: jest.fn(),
 };

--- a/src/components/home/DetectDockerModal.spec.tsx
+++ b/src/components/home/DetectDockerModal.spec.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { shell } from 'electron';
 import { fireEvent } from '@testing-library/dom';
-import * as system from 'utils/system';
-import { injections, mockProperty, renderWithProviders } from 'utils/tests';
+import os from 'os';
+import { injections, renderWithProviders } from 'utils/tests';
 import DetectDockerModal, { dockerLinks } from './DetectDockerModal';
 
-jest.mock('utils/system');
+jest.mock('os');
 
+const mockOS = os as jest.Mocked<typeof os>;
 const mockDockerService = injections.dockerService as jest.Mocked<
   typeof injections.dockerService
 >;
@@ -23,6 +24,10 @@ describe('DetectDockerModal component', () => {
     };
     return renderWithProviders(<DetectDockerModal />, { initialState });
   };
+
+  beforeEach(() => {
+    mockOS.platform.mockReturnValue('darwin');
+  });
 
   it('should display UI elements', () => {
     const { getByText, getAllByText } = renderComponent();
@@ -50,7 +55,7 @@ describe('DetectDockerModal component', () => {
   });
 
   it('should display download button for mac', () => {
-    mockProperty(system, 'platform', 'mac');
+    mockOS.platform.mockReturnValue('darwin');
     const { getByText, getByLabelText } = renderComponent();
     expect(getByText('Download Docker Desktop')).toBeInTheDocument();
     expect(getByLabelText('icon: apple')).toBeInTheDocument();
@@ -58,7 +63,7 @@ describe('DetectDockerModal component', () => {
 
   it('should open browser when download button clicked on mac', () => {
     shell.openExternal = jest.fn().mockResolvedValue(true);
-    mockProperty(system, 'platform', 'mac');
+    mockOS.platform.mockReturnValue('darwin');
     const { getByText } = renderComponent();
     fireEvent.click(getByText('Download Docker Desktop'));
     expect(shell.openExternal).toBeCalledTimes(1);
@@ -66,7 +71,7 @@ describe('DetectDockerModal component', () => {
   });
 
   it('should display download button for windows', () => {
-    mockProperty(system, 'platform', 'windows');
+    mockOS.platform.mockReturnValue('win32');
     const { getByText, getByLabelText } = renderComponent();
     expect(getByText('Download Docker Desktop')).toBeInTheDocument();
     expect(getByLabelText('icon: windows')).toBeInTheDocument();
@@ -74,7 +79,7 @@ describe('DetectDockerModal component', () => {
 
   it('should open browser when download button clicked on windows', () => {
     shell.openExternal = jest.fn().mockResolvedValue(true);
-    mockProperty(system, 'platform', 'windows');
+    mockOS.platform.mockReturnValue('win32');
     const { getByText } = renderComponent();
     fireEvent.click(getByText('Download Docker Desktop'));
     expect(shell.openExternal).toBeCalledTimes(1);
@@ -82,7 +87,7 @@ describe('DetectDockerModal component', () => {
   });
 
   it('should display download button for linux', () => {
-    mockProperty(system, 'platform', 'linux');
+    mockOS.platform.mockReturnValue('linux');
     const { getByText, getAllByLabelText } = renderComponent();
     expect(getByText('Download Docker')).toBeInTheDocument();
     expect(getByText('Download Docker Compose')).toBeInTheDocument();
@@ -91,7 +96,7 @@ describe('DetectDockerModal component', () => {
 
   it('should open browser when download buttons clicked on linux', () => {
     shell.openExternal = jest.fn().mockResolvedValue(true);
-    mockProperty(system, 'platform', 'linux');
+    mockOS.platform.mockReturnValue('linux');
     const { getByText } = renderComponent();
     fireEvent.click(getByText('Download Docker'));
     expect(shell.openExternal).toBeCalledTimes(1);

--- a/src/components/home/DetectDockerModal.tsx
+++ b/src/components/home/DetectDockerModal.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import { Button, Modal, Result } from 'antd';
 import { usePrefixedTranslation } from 'hooks';
 import { useStoreActions, useStoreState } from 'store';
-import { platform, PolarPlatform } from 'utils/system';
+import { getPolarPlatform, PolarPlatform } from 'utils/system';
 import { DetailsList } from 'components/common';
 
 const Styled = {
@@ -42,6 +42,7 @@ const buttonIcons: Record<PolarPlatform, string> = {
 };
 
 const DetectDockerModal: React.FC = () => {
+  const platform = getPolarPlatform();
   const { l } = usePrefixedTranslation('cmps.home.DetectDockerModal');
   const {
     dockerVersions: { docker, compose },

--- a/src/lib/docker/composeFile.ts
+++ b/src/lib/docker/composeFile.ts
@@ -6,6 +6,7 @@ import { bitcoind, lnd } from './nodeTemplates';
 export interface ComposeService {
   image: string;
   container_name: string;
+  environment: Record<string, string>;
   hostname: string;
   command: string;
   volumes: string[];

--- a/src/lib/docker/dockerService.ts
+++ b/src/lib/docker/dockerService.ts
@@ -202,9 +202,9 @@ class DockerService implements DockerLibrary {
       },
     };
 
-    if (isLinux) {
+    if (isLinux()) {
       const { uid, gid } = os.userInfo();
-      info(`env: uid=${uid} gid=${gid}`);
+      debug(`env: uid=${uid} gid=${gid}`);
       args.env = {
         ...args.env,
         // add user/group id's to env so that file permissions on the

--- a/src/lib/docker/nodeTemplates.ts
+++ b/src/lib/docker/nodeTemplates.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/camelcase */
+/* eslint-disable no-template-curly-in-string */
 import { ComposeService } from './composeFile';
 
 // simple function to remove all line-breaks and extra white-space inside of a string
@@ -12,6 +13,10 @@ export const bitcoind = (
 ): ComposeService => ({
   image: `polarlightning/bitcoind:${version}`,
   container_name: container,
+  environment: {
+    USERID: '${USERID:-1000}',
+    GROUPID: '${GROUPID:-1000}',
+  },
   hostname: name,
   // Note: escape ($) rpcauth with ($$)
   command: trimInside(`
@@ -51,6 +56,10 @@ export const lnd = (
 ): ComposeService => ({
   image: `polarlightning/lnd:${version}`,
   container_name: container,
+  environment: {
+    USERID: '${USERID:-1000}',
+    GROUPID: '${GROUPID:-1000}',
+  },
   hostname: name,
   command: trimInside(`
     lnd

--- a/src/utils/system.spec.ts
+++ b/src/utils/system.spec.ts
@@ -1,5 +1,5 @@
 import os from 'os';
-import { normalizePlatform } from './system';
+import { getPolarPlatform, isLinux, isMac, isWindows } from './system';
 
 jest.mock('os');
 
@@ -8,17 +8,17 @@ const mockOS = os as jest.Mocked<typeof os>;
 describe('System Util', () => {
   it('should return the correct platform on mac', () => {
     mockOS.platform.mockReturnValue('darwin');
-    expect(normalizePlatform()).toBe('mac');
+    expect(getPolarPlatform()).toBe('mac');
   });
 
   it('should return the correct platform on windows', () => {
     mockOS.platform.mockReturnValue('win32');
-    expect(normalizePlatform()).toBe('windows');
+    expect(getPolarPlatform()).toBe('windows');
   });
 
   it('should return the correct platform on linux', () => {
     mockOS.platform.mockReturnValue('linux');
-    expect(normalizePlatform()).toBe('linux');
+    expect(getPolarPlatform()).toBe('linux');
   });
 
   it('should return unknown platform for others', () => {
@@ -33,7 +33,28 @@ describe('System Util', () => {
     ];
     others.forEach(platform => {
       mockOS.platform.mockReturnValue(platform);
-      expect(normalizePlatform()).toBe('unknown');
+      expect(getPolarPlatform()).toBe('unknown');
     });
+  });
+
+  it('should return correct isMac value', () => {
+    mockOS.platform.mockReturnValue('aix');
+    expect(isMac()).toBe(false);
+    mockOS.platform.mockReturnValue('darwin');
+    expect(isMac()).toBe(true);
+  });
+
+  it('should return correct isWindows value', () => {
+    mockOS.platform.mockReturnValue('aix');
+    expect(isWindows()).toBe(false);
+    mockOS.platform.mockReturnValue('win32');
+    expect(isWindows()).toBe(true);
+  });
+
+  it('should return correct isLinux value', () => {
+    mockOS.platform.mockReturnValue('aix');
+    expect(isLinux()).toBe(false);
+    mockOS.platform.mockReturnValue('linux');
+    expect(isLinux()).toBe(true);
   });
 });

--- a/src/utils/system.ts
+++ b/src/utils/system.ts
@@ -2,7 +2,10 @@ import os from 'os';
 
 export type PolarPlatform = 'mac' | 'windows' | 'linux' | 'unknown';
 
-export const normalizePlatform = () => {
+/**
+ * A wrapper function to simplify os detection throughout the app
+ */
+export const getPolarPlatform = () => {
   switch (os.platform()) {
     case 'darwin':
       return 'mac';
@@ -15,12 +18,10 @@ export const normalizePlatform = () => {
   }
 };
 
-export const platform: PolarPlatform = normalizePlatform();
+const is = (p: PolarPlatform) => p === getPolarPlatform();
 
-const is = (p: PolarPlatform) => p === platform;
+export const isMac = () => is('mac');
 
-export const isMac = is('mac');
+export const isWindows = () => is('windows');
 
-export const isWindows = is('windows');
-
-export const isLinux = is('linux');
+export const isLinux = () => is('linux');


### PR DESCRIPTION
Partially fixes #227

### Description

Docker containers on linux share file permissions with hosts. Assigning the same uid/gid from the host user to the container user ensures that the files can be read/write from both sides.

There's a really good write-up [here](https://www.berthon.eu/2018/containers-volumes-and-file-permissions/).

### Steps to Test

1. Run the app on a linux
2. Confirm the nodes boot up successfully

