### PR TITLE
feat(clightning): add support for c-lightning v0.8.0

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -60,7 +60,7 @@ $ cd clightning
 $ docker build --build-arg CLN_VERSION=<version> -t polarlightning/clightning:<version> .
 ```
 
-Replace `<version>` with the desired c-lightning version (ex: `0.7.3`).
+Replace `<version>` with the desired c-lightning version (ex: `0.8.0`).
 
 **Push to Docker Hub**
 

--- a/src/components/network/NetworkView.spec.tsx
+++ b/src/components/network/NetworkView.spec.tsx
@@ -136,7 +136,7 @@ describe('NetworkView Component', () => {
   });
 
   it('should not display a message if the docker images are found', async () => {
-    const images = ['bitcoind:0.19.0.1', 'lnd:0.8.2-beta', 'clightning:0.7.3'];
+    const images = ['bitcoind:0.19.0.1', 'lnd:0.8.2-beta', 'clightning:0.8.0'];
     const { queryByText } = renderComponent('1', Status.Stopped, images);
     expect(
       queryByText(

--- a/src/lib/docker/dockerService.ts
+++ b/src/lib/docker/dockerService.ts
@@ -16,7 +16,7 @@ import {
 import stripAnsi from 'strip-ansi';
 import { DockerLibrary, DockerVersions, Network, NetworksFile } from 'types';
 import { networksPath, nodePath } from 'utils/config';
-import { DOCKER_REPO } from 'utils/constants';
+import { DOCKER_REPO, dockerConfigs } from 'utils/constants';
 import { exists, read, write } from 'utils/files';
 import { isLinux } from 'utils/system';
 import ComposeFile from './composeFile';
@@ -252,8 +252,9 @@ class DockerService implements DockerLibrary {
       const nodeDir = nodePath(network, node.implementation, node.name);
       await ensureDir(nodeDir);
       if (node.implementation === 'c-lightning') {
-        await ensureDir(join(nodeDir, 'data'));
-        await ensureDir(join(nodeDir, 'rest-api'));
+        const { dataDir, apiDir } = dockerConfigs['c-lightning'];
+        await ensureDir(join(nodeDir, dataDir as string));
+        await ensureDir(join(nodeDir, apiDir as string));
       }
     }
   }

--- a/src/lib/docker/nodeTemplates.ts
+++ b/src/lib/docker/nodeTemplates.ts
@@ -130,8 +130,8 @@ export const clightning = (
   `),
   restart: 'always',
   volumes: [
-    `./volumes/${dockerConfigs['c-lightning'].volumeDirName}/${name}/data:/home/clightning/.lightning`,
-    `./volumes/${dockerConfigs['c-lightning'].volumeDirName}/${name}/rest-api:/opt/c-lightning-rest/certs`,
+    `./volumes/${dockerConfigs['c-lightning'].volumeDirName}/${name}/${dockerConfigs['c-lightning'].dataDir}:/home/clightning/.lightning`,
+    `./volumes/${dockerConfigs['c-lightning'].volumeDirName}/${name}/${dockerConfigs['c-lightning'].apiDir}:/opt/c-lightning-rest/certs`,
   ],
   expose: [
     '8080', // REST

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -36,7 +36,8 @@ export enum LndVersion {
 }
 
 export enum CLightningVersion {
-  latest = '0.7.3',
+  latest = '0.8.0',
+  '0.7.3' = '0.7.3',
 }
 
 // the highest version of bitcoind that each LND version works with
@@ -48,6 +49,7 @@ export const LndCompatibility: Record<LndVersion, BitcoindVersion> = {
 
 // the highest version of bitcoind that each c-lightning version works with
 export const CLightningCompatibility: Record<CLightningVersion, BitcoindVersion> = {
+  '0.8.0': BitcoindVersion.latest,
   '0.7.3': BitcoindVersion.latest,
 };
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -89,4 +89,6 @@ export type NodeImplementation =
 
 export interface DockerConfig {
   volumeDirName: string;
+  dataDir?: string;
+  apiDir?: string;
 }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -7,7 +7,7 @@ import { dockerConfigs } from './constants';
 /**
  * root path where application data is stored
  */
-export const dataPath = join(remote.app.getPath('userData'), 'data');
+export const dataPath = join(remote.app.getPath('home'), '.polar');
 
 /**
  * path where networks data is stored

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -58,7 +58,9 @@ export const dockerConfigs: Record<NodeImplementation, DockerConfig> = {
     volumeDirName: 'lnd',
   },
   'c-lightning': {
-    volumeDirName: 'cln',
+    volumeDirName: 'c-lightning',
+    dataDir: 'lightningd',
+    apiDir: 'rest-api',
   },
   eclair: {
     volumeDirName: 'eclair',


### PR DESCRIPTION
### Description

This PR adds support for c-lightning v0.8.0 which was recently released. 

#### BREAKING CHANGE 

 With c-lighting changing the folder structure of their dataDir in v0.8.0, lightningd was unable to create the lightning-rpc socket file due to 'path too long' errors on Mac. The node data was originally stored in ~/Library/Application Support/polar/data/networks/. This has now been changed to ~/.polar on all OS's. Due to this change, networks that were created in Polar v0.1.0 will no longer be displayed in the app. They will need to be manually moved or re-created.

To move the previous networks to the new location, you must stop any running networks and close the Polar app. Then move the 'networks' folder depending on your OS to the new location:

Location in v0.1.0
Mac: ~/Library/Application Support/polar/data/networks/
Linux: ~/config/polar/data/networks/
Windows: ~/AppData/Roaming/polar/data/networks/

New location in v0.2.0
All OS's: ~/.polar/networks/

### Screenshots

![image](https://user-images.githubusercontent.com/1356600/71221517-e1fd4000-229a-11ea-9b65-ef6b93696738.png)

![image](https://user-images.githubusercontent.com/1356600/71221568-11ac4800-229b-11ea-9838-d1a27f3fc67f.png)
