### PR TITLE
fix(channels): fix a few issues found during cross-platform testing

### DIFF
--- a/docker/clightning/Dockerfile
+++ b/docker/clightning/Dockerfile
@@ -134,7 +134,7 @@ RUN apt-get update -y \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # install c-lightning-REST API plugin
-RUN git clone https://github.com/ride-the-lightning/c-lightning-rest /opt/c-lightning-rest/ \
+RUN git clone --branch fix/channels https://github.com/jamaljsr/c-lightning-rest /opt/c-lightning-rest/ \
   && cd /opt/c-lightning-rest \
   && npm install \ 
   && chmod -R a+rw /opt/c-lightning-rest

--- a/src/components/terminal/DockerTerminal.tsx
+++ b/src/components/terminal/DockerTerminal.tsx
@@ -68,7 +68,7 @@ const nodeConfig: Record<string, { user: string; alias: string }> = {
   },
   'c-lightning': {
     user: 'clightning',
-    alias: '',
+    alias: 'alias lightning-cli="lightning-cli --network regtest"',
   },
   bitcoind: {
     user: 'bitcoin',

--- a/src/lib/lightning/clightning/clightningService.ts
+++ b/src/lib/lightning/clightning/clightningService.ts
@@ -60,7 +60,9 @@ class CLightningService implements LightningService {
     return (
       channels
         // only include the channels that were initiated by this node
-        .filter(chan => chan.fundingAllocationMsat[pubkey] > 0)
+        .filter(
+          chan => chan.fundingAllocationMsat && chan.fundingAllocationMsat[pubkey] > 0,
+        )
         .filter(c => ChannelStateToStatus[c.state] !== 'Closed')
         .map(c => {
           const status = ChannelStateToStatus[c.state];

--- a/src/store/models/lightning.ts
+++ b/src/store/models/lightning.ts
@@ -205,10 +205,15 @@ const lightningModel: LightningModel = {
     ) => {
       const api = injections.lightningFactory.getService(node);
       await api.closeChannel(node, channelPoint);
+      // add a small delay to allow nodes to create the closing txn and broadcast it
+      await actions.waitForNodes([node]);
       // mine some blocks to confirm the txn
       const network = getStoreState().network.networkById(node.networkId);
       const btcNode = network.nodes.bitcoin[0];
-      await getStoreActions().bitcoind.mine({ blocks: 1, node: btcNode });
+      await getStoreActions().bitcoind.mine({
+        blocks: BLOCKS_TIL_COMFIRMED,
+        node: btcNode,
+      });
       // add a small delay to allow nodes to process the mined blocks
       await actions.waitForNodes([node]);
       // synchronize the chart with the new channel

--- a/src/store/models/lightning.ts
+++ b/src/store/models/lightning.ts
@@ -3,7 +3,7 @@ import { LightningNode, Status } from 'shared/types';
 import * as PLN from 'lib/lightning/types';
 import { Network, StoreInjections } from 'types';
 import { delay } from 'utils/async';
-import { BLOCKS_TIL_COMFIRMED } from 'utils/constants';
+import { BLOCKS_TIL_CONFIRMED } from 'utils/constants';
 import { fromSatsNumeric } from 'utils/units';
 import { RootModel } from './';
 
@@ -152,7 +152,7 @@ const lightningModel: LightningModel = {
       const coins = fromSatsNumeric(sats);
       await injections.bitcoindService.sendFunds(btcNode, address, coins);
       await getStoreActions().bitcoind.mine({
-        blocks: BLOCKS_TIL_COMFIRMED,
+        blocks: BLOCKS_TIL_CONFIRMED,
         node: btcNode,
       });
       // add a small delay to allow nodes to process the mined blocks
@@ -188,7 +188,7 @@ const lightningModel: LightningModel = {
         network.nodes.bitcoin.find(n => n.name === from.backendName) ||
         network.nodes.bitcoin[0];
       await getStoreActions().bitcoind.mine({
-        blocks: BLOCKS_TIL_COMFIRMED,
+        blocks: BLOCKS_TIL_CONFIRMED,
         node: btcNode,
       });
       // add a small delay to allow nodes to process the mined blocks
@@ -211,7 +211,7 @@ const lightningModel: LightningModel = {
       const network = getStoreState().network.networkById(node.networkId);
       const btcNode = network.nodes.bitcoin[0];
       await getStoreActions().bitcoind.mine({
-        blocks: BLOCKS_TIL_COMFIRMED,
+        blocks: BLOCKS_TIL_CONFIRMED,
         node: btcNode,
       });
       // add a small delay to allow nodes to process the mined blocks

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -5,7 +5,7 @@ export const DOCKER_REPO = 'polarlightning';
 
 // bitcoind
 export const INITIAL_BLOCK_REWARD = 50;
-export const BLOCKS_TIL_COMFIRMED = 6;
+export const BLOCKS_TIL_CONFIRMED = 6;
 export const COINBASE_MATURITY_DELAY = 100;
 // https://github.com/bitcoin/bitcoin/blob/v0.19.0.1/src/chainparams.cpp#L258
 export const HALVING_INTERVAL = 150;


### PR DESCRIPTION
Just fixing up some small bugs found when testing on Windows and Linux
- fix LND channels remaining pending after close
- add terminal alias so lightning-cli always uses regtest
- fix reopened c-lightning channels not showing in the designer
- fix race condition during c-lightning channel opening with deposit
