### PR TITLE
feat: make bitcoind's ZeroMQ servers reachable on LAN

### DIFF
--- a/src/components/designer/bitcoind/ConnectTab.tsx
+++ b/src/components/designer/bitcoind/ConnectTab.tsx
@@ -37,6 +37,8 @@ const ConnectTab: React.FC<Props> = ({ node }) => {
 
   const details: DetailValues = [
     { label: l('rpcHost'), value: `http://127.0.0.1:${node.ports.rpc}` },
+    { label: l('zmqBlockHost'), value: `tcp://127.0.0.1:${node.ports.zmqBlock}` },
+    { label: l('zmqTxHost'), value: `tcp://127.0.0.1:${node.ports.zmqTx}` },
     { label: l('rpcUser'), value: bitcoinCredentials.user },
     { label: l('rpcPass'), value: bitcoinCredentials.pass },
   ].map(({ label, value }) => ({

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -37,6 +37,8 @@
   "cmps.designer.bitcoind.BitcoinDetails.waitingNotice": "Waiting for bitcoind to come online",
   "cmps.designer.bitcoind.BitcoinDetails.getInfoErr": "Unable to connect to node",
   "cmps.designer.bitcoind.ConnectTab.rpcHost": "RPC Host",
+  "cmps.designer.bitcoind.ConnectTab.zmqBlockHost": "ZMQ Block Host",
+  "cmps.designer.bitcoind.ConnectTab.zmqTxHost": "ZMQ Transaction Host",
   "cmps.designer.bitcoind.ConnectTab.rpcUser": "Username",
   "cmps.designer.bitcoind.ConnectTab.rpcPass": "Password",
   "cmps.designer.bitcoind.ConnectTab.apiDocs": "API Docs",

--- a/src/lib/docker/composeFile.ts
+++ b/src/lib/docker/composeFile.ts
@@ -35,7 +35,14 @@ class ComposeFile {
   addBitcoind(node: BitcoinNode) {
     const { name, version, ports } = node;
     const container = getContainerName(node);
-    this.content.services[name] = bitcoind(name, container, version, ports.rpc);
+    this.content.services[name] = bitcoind(
+      name,
+      container,
+      version,
+      ports.rpc,
+      ports.zmqBlock,
+      ports.zmqTx,
+    );
   }
 
   addLnd(node: LndNode, backend: CommonNode) {

--- a/src/lib/docker/nodeTemplates.spec.ts
+++ b/src/lib/docker/nodeTemplates.spec.ts
@@ -3,7 +3,7 @@ import { bitcoind, lnd } from './nodeTemplates';
 
 describe('nodeTemplates', () => {
   it('should create a valid bitcoind config', () => {
-    const node = bitcoind('mynode', 'polar-mynode', '0.18.1', 18443);
+    const node = bitcoind('mynode', 'polar-mynode', '0.18.1', 18443, 28334, 29335);
     expect(node.image).toContain('bitcoind');
     expect(node.container_name).toEqual('polar-mynode');
     expect(node.volumes[0]).toContain('mynode');

--- a/src/lib/docker/nodeTemplates.ts
+++ b/src/lib/docker/nodeTemplates.ts
@@ -11,6 +11,8 @@ export const bitcoind = (
   container: string,
   version: string,
   rpcPort: number,
+  zmqBlockPort: number,
+  zmqTxPort: number,
 ): ComposeService => ({
   image: `polarlightning/bitcoind:${version}`,
   container_name: container,
@@ -48,6 +50,8 @@ export const bitcoind = (
   ],
   ports: [
     `${rpcPort}:18443`, // RPC
+    `${zmqBlockPort}:28334`, // ZMQ blocks
+    `${zmqTxPort}:28335`, // ZMQ txns
   ],
 });
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -51,6 +51,8 @@ export interface BitcoinNode extends CommonNode {
   peers: string[];
   ports: {
     rpc: number;
+    zmqBlock: number;
+    zmqTx: number;
   };
 }
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -45,6 +45,8 @@ export const denominationNames: { [key in Denomination]: string } = {
 export const BasePorts = {
   bitcoind: {
     rest: 18443,
+    zmqBlock: 28334,
+    zmqTx: 29335,
   },
   lnd: {
     rest: 8081,

--- a/src/utils/network.spec.ts
+++ b/src/utils/network.spec.ts
@@ -26,13 +26,53 @@ describe('Network Utils', () => {
       network = getNetwork();
     });
 
-    it('should update the port for bitcoin rpc', async () => {
+    it('should update the ports for bitcoind', async () => {
       mockDetectPort.mockImplementation(port => Promise.resolve(port + 1));
       network.nodes.lightning = [];
-      const port = network.nodes.bitcoin[0].ports.rpc;
+      const restPort = network.nodes.bitcoin[0].ports.rpc;
+      const zmqBlockPort = network.nodes.bitcoin[0].ports.zmqBlock;
+      const zmqTxPort = network.nodes.bitcoin[0].ports.zmqTx;
       const ports = (await getOpenPorts(network)) as OpenPorts;
       expect(ports).toBeDefined();
-      expect(ports[network.nodes.bitcoin[0].name].rpc).toBe(port + 1);
+      expect(ports[network.nodes.bitcoin[0].name].rpc).toBe(restPort + 1);
+      expect(ports[network.nodes.bitcoin[0].name].zmqBlock).toBe(zmqBlockPort + 1);
+      expect(ports[network.nodes.bitcoin[0].name].zmqTx).toBe(zmqTxPort + 1);
+    });
+
+    it('should update the rest port for bitcoind', async () => {
+      const portsInUse = [18443];
+      mockDetectPort.mockImplementation(port =>
+        Promise.resolve(portsInUse.includes(port) ? port + 1 : port),
+      );
+      network.nodes.lightning = [];
+      const restPort = network.nodes.bitcoin[0].ports.rpc;
+      const ports = (await getOpenPorts(network)) as OpenPorts;
+      expect(ports).toBeDefined();
+      expect(ports[network.nodes.bitcoin[0].name].rpc).toBe(restPort + 1);
+    });
+
+    it('should update the zmq block port for bitcoind', async () => {
+      const portsInUse = [28334];
+      mockDetectPort.mockImplementation(port =>
+        Promise.resolve(portsInUse.includes(port) ? port + 1 : port),
+      );
+      network.nodes.lightning = [];
+      const zmqBlockPort = network.nodes.bitcoin[0].ports.zmqBlock;
+      const ports = (await getOpenPorts(network)) as OpenPorts;
+      expect(ports).toBeDefined();
+      expect(ports[network.nodes.bitcoin[0].name].zmqBlock).toBe(zmqBlockPort + 1);
+    });
+
+    it('should update the zmq tx port for bitcoind', async () => {
+      const portsInUse = [29335];
+      mockDetectPort.mockImplementation(port =>
+        Promise.resolve(portsInUse.includes(port) ? port + 1 : port),
+      );
+      network.nodes.lightning = [];
+      const zmqTxPort = network.nodes.bitcoin[0].ports.zmqTx;
+      const ports = (await getOpenPorts(network)) as OpenPorts;
+      expect(ports).toBeDefined();
+      expect(ports[network.nodes.bitcoin[0].name].zmqTx).toBe(zmqTxPort + 1);
     });
 
     it('should update the grpc ports for lightning nodes', async () => {


### PR DESCRIPTION
Closes #296 

### Description

This PR makes bitcoind's ZeroMQ servers reachable on LAN instead of only via the private network (172.x.x.x).

Some changes had to be made in `createBitcoindNetworkNode()` to be able to accomplish this as the ZeroMQ block port would otherwise collide with the ZeroMQ tx port (because default port numbers are just after one another, 28334 and 28335, the "+ id"-way won't work anymore ).
According to the new code, the ZeroMQ block port will always start 1 above the highest ZeroMQ tx port found (and Tx port 2 above).  
A similar issue can also appear in `getOpenPorts()`. As the port test is done individually and not together, `getOpenPorts()` could return the same port number for both ZeroMQ block and ZeroMQ tx.
I've made a new function where you pass in a group of ports to be tested, so that the function could keep track of which ports are already marked to be allocated.  
I've [uploaded it here](https://pastebin.com/pKEinxKt), it's not in the current pull request.

Related but a more general problem with `createBitcoindNetworkNode()`, `createLndNetworkNode` and `createCLightningNetworkNode` and when you add nodes in the Designer, are that AFAICT they do not use `getOpenPorts`/`getOpenPortRange`, so it could theoretically collide with an already used port.  
This PR does not address this.

This is currently a **breaking change**, as networks created before this commit would show up with the wrong IP for the zmq servers (127.x.x.x when it's really 172.x.x.x) and port numbers as `undefined` as they wouldn't have the port number saved to the `docker-compose.yml` file.  
I do not know the best way to solve this, what do you think?

Cheers!

### Steps to Test

1. Add a new network with 2+ bitcoind nodes
2. Add another bitcoind node from the Designer
3. Check the connectivity tab for each bitcoind node
4. Try to connect to the bitcoind nodes from another device in the LAN

### Screenshots

![New fields in `ConnectTab`](https://user-images.githubusercontent.com/3824379/74957994-99801100-5408-11ea-946e-c642c928e2c8.png)

