### PR TITLE
fix(designer): fix corrupt redux state causing errors

### DIFF
--- a/src/components/home/NetworkCard.tsx
+++ b/src/components/home/NetworkCard.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
-import styled from '@emotion/styled';
 import { LinkOutlined, ThunderboltOutlined } from '@ant-design/icons';
+import styled from '@emotion/styled';
 import { Card, Col, Row, Statistic } from 'antd';
 import { usePrefixedTranslation } from 'hooks';
 import { useStoreActions } from 'store';
@@ -18,11 +18,15 @@ const NetworkCard: React.FC<{ network: Network }> = ({ network }) => {
   const { l } = usePrefixedTranslation('cmps.home.NetworkCard');
   const { navigateTo } = useStoreActions(s => s.app);
   const { setActiveId } = useStoreActions(s => s.designer);
+  const { clearNodes: clearLnNodes } = useStoreActions(s => s.lightning);
+  const { clearNodes: clearBtcNodes } = useStoreActions(s => s.bitcoind);
 
   const handleClick = useCallback(() => {
     setActiveId(network.id);
+    clearLnNodes();
+    clearBtcNodes();
     navigateTo(NETWORK_VIEW(network.id));
-  }, [network.id, setActiveId, navigateTo]);
+  }, [network.id, setActiveId, clearLnNodes, clearBtcNodes, navigateTo]);
 
   return (
     <Styled.Card

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -242,6 +242,7 @@
   "cmps.network.NetworkView.deleteCancelBtn": "Cancel",
   "cmps.network.NetworkView.deleteSuccess": "The network '{{name}}' and its data has been deleted!",
   "cmps.network.NetworkView.deleteError": "Unable to delete the network",
+  "cmps.network.NetworkView.getInfoError": "Failed to fetch the bitcoin block height",
   "cmps.network.NewNetwork.title": "Create a new Lightning Network",
   "cmps.network.NewNetwork.nameLabel": "Network Name",
   "cmps.network.NewNetwork.namePhldr": "My Lightning Simnet",

--- a/src/store/models/bitcoind.ts
+++ b/src/store/models/bitcoind.ts
@@ -20,6 +20,7 @@ export interface BitcoindNodeModel {
 export interface BitcoindModel {
   nodes: BitcoindNodeMapping;
   removeNode: Action<BitcoindModel, string>;
+  clearNodes: Action<BitcoindModel, void>;
   setInfo: Action<
     BitcoindModel,
     { node: BitcoinNode; chainInfo: ChainInfo; walletInfo: WalletInfo }
@@ -39,6 +40,9 @@ const bitcoindModel: BitcoindModel = {
   // reducer actions (mutations allowed thx to immer)
   removeNode: action((state, name) => {
     delete state.nodes[name];
+  }),
+  clearNodes: action(state => {
+    state.nodes = {};
   }),
   setInfo: action((state, { node, chainInfo, walletInfo }) => {
     if (!state.nodes[node.name]) state.nodes[node.name] = {};

--- a/src/store/models/lightning.ts
+++ b/src/store/models/lightning.ts
@@ -44,6 +44,7 @@ export interface PayInvoicePayload {
 export interface LightningModel {
   nodes: LightningNodeMapping;
   removeNode: Action<LightningModel, string>;
+  clearNodes: Action<LightningModel, void>;
   setInfo: Action<LightningModel, { node: LightningNode; info: PLN.LightningNodeInfo }>;
   getInfo: Thunk<LightningModel, LightningNode, StoreInjections, RootModel>;
   setWalletBalance: Action<
@@ -92,6 +93,9 @@ const lightningModel: LightningModel = {
     if (state.nodes[name]) {
       delete state.nodes[name];
     }
+  }),
+  clearNodes: action(state => {
+    state.nodes = {};
   }),
   setInfo: action((state, { node, info }) => {
     if (!state.nodes[node.name]) state.nodes[node.name] = {};


### PR DESCRIPTION
### Description

Fixes an issue where global state data from one network is leftover and used by another network. This causes some errors to be thrown when refreshing the network from all nodes.

### Screenshots

![image](https://user-images.githubusercontent.com/1356600/75561058-5b8c7980-5a14-11ea-9a13-f36281b3e78e.png)
