### PR TITLE
fix(terminal): fix broken line wrapping for long commands

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,6 @@
 
 Small Stuff
 
-- fix pasting text in terminal
 - implement real-time channel updates from LND via GRPC streams
 - implement option to auto-mine every X minutes
 - switch renovatebot to dependabot and use automatic security fixes
@@ -14,10 +13,7 @@ Small Stuff
 
 Bigger things
 
-- create a splash page website for lightningpolar.com
 - add block explorer (https://github.com/janoside/btc-rpc-explorer)
 - add grpc API explorer (https://github.com/grpc-ecosystem/awesome-grpc#gui)
 - add support for eclair, btcd
-- live theme changer (https://medium.com/@mzohaib.qc/ant-design-dynamic-runtime-theme-1f9a1a030ba0)
-- dark theme UI (https://material.io/design/color/dark-theme.html)
 - POC testing-library for testcafe (https://testing-library.com/docs/testcafe-testing-library/intro)


### PR DESCRIPTION
Closes #308 

### Description

This PR fixes a bug in the terminal with long wrapping text. The overflow characters would be displayed on the same line instead of the next. This cause the whole command to be unreadable.

### Steps to Test

1. Open a terminal for one of the nodes
2. Type or paste in a long command
3. Confirm that it wraps to the next line properly

### Screenshots

Before
![term-before](https://user-images.githubusercontent.com/1356600/75601273-a5fb0e00-5a87-11ea-8f48-f517f672baf5.gif)

After
![term-after](https://user-images.githubusercontent.com/1356600/75601285-ab585880-5a87-11ea-936a-314caa873ab8.gif)

