### PR TITLE
Fix OS compatibility issues

### DIFF
--- a/src/components/common/NavMenu.tsx
+++ b/src/components/common/NavMenu.tsx
@@ -14,7 +14,6 @@ import { NETWORK_IMPORT, NETWORK_NEW, NODE_IMAGES } from 'components/routing';
 const Styled = {
   Menu: styled.div`
     float: right;
-    margin-top: 9px;
   `,
   MenuIcon: styled(MenuOutlined)`
     font-size: 1.2rem;

--- a/src/components/designer/SidebarCard.tsx
+++ b/src/components/designer/SidebarCard.tsx
@@ -10,24 +10,4 @@ export default styled(Card)`
   border-radius: 2px;
   box-shadow: 0 10px 20px rgba(0, 0, 0, 0.1);
   overflow: auto;
-
-  &::-webkit-scrollbar {
-    width: 8px;
-    background-color: rgba(0, 0, 0, 0);
-    border-radius: 10px;
-  }
-
-  &::-webkit-scrollbar:hover {
-    background-color: rgba(0, 0, 0, 0.1);
-  }
-
-  &::-webkit-scrollbar-thumb:vertical {
-    background-color: rgba(0, 0, 0, 0.2);
-    border-radius: 10px;
-  }
-
-  &::-webkit-scrollbar-thumb:vertical:active {
-    background-color: rgba(0, 0, 0, 0.6);
-    border-radius: 10px;
-  }
 `;

--- a/src/components/designer/bitcoind/ActionsTab.tsx
+++ b/src/components/designer/bitcoind/ActionsTab.tsx
@@ -19,7 +19,7 @@ interface Props {
 
 const ActionsTab: React.FC<Props> = ({ node }) => {
   return (
-    <Form wrapperCol={{ span: 24 }}>
+    <Form labelCol={{ span: 24 }}>
       {node.status === Status.Started && (
         <>
           <MineBlocksInput node={node} />

--- a/src/components/designer/lightning/ActionsTab.tsx
+++ b/src/components/designer/lightning/ActionsTab.tsx
@@ -19,7 +19,7 @@ interface Props {
 
 const ActionsTab: React.FC<Props> = ({ node }) => {
   return (
-    <Form wrapperCol={{ span: 24 }}>
+    <Form labelCol={{ span: 24 }}>
       {node.status === Status.Started && (
         <>
           <Deposit node={node} />

--- a/src/components/designer/link/CloseChannelButton.tsx
+++ b/src/components/designer/link/CloseChannelButton.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { CloseOutlined } from '@ant-design/icons';
 import { Button, Modal } from 'antd';
 import { usePrefixedTranslation } from 'hooks';
-import { LightningNode } from 'shared/types';
+import { LightningNode, Status } from 'shared/types';
 import { useStoreActions } from 'store';
 
 interface Props {
@@ -17,6 +17,10 @@ const CloseChannelButton: React.FC<Props> = ({ node, channelPoint, type }) => {
   const { closeChannel } = useStoreActions(s => s.lightning);
 
   const showCloseChanModal = () => {
+    if (node.status !== Status.Started) {
+      notify({ message: l('error'), error: new Error(l('notStarted')) });
+      return;
+    }
     Modal.confirm({
       title: l('title'),
       okText: l('confirmBtn'),

--- a/src/components/network/NewNetwork.tsx
+++ b/src/components/network/NewNetwork.tsx
@@ -88,7 +88,7 @@ const NewNetwork: React.SFC = () => {
               <Styled.Divider orientation="left">{l('customLabel')}</Styled.Divider>
               <Row>
                 {customNodes.map(node => (
-                  <Col span={8} key={node.id}>
+                  <Col span={6} key={node.id}>
                     <Form.Item
                       name={['customNodes', node.id]}
                       label={node.name}

--- a/src/components/nodeImages/CustomImageModal.spec.tsx
+++ b/src/components/nodeImages/CustomImageModal.spec.tsx
@@ -85,8 +85,8 @@ describe('CustomImageModal Component', () => {
     const { getByLabelText, changeSelect } = await renderComponent(newImage);
     const impl = getByLabelText('Command') as HTMLTextAreaElement;
     expect(impl.value).toContain('lnd');
-    changeSelect('Implementation', 'c-lightning');
-    expect(impl.value).toContain('lightningd');
+    changeSelect('Implementation', 'Eclair');
+    expect(impl.value).toContain('polar-eclair');
   });
 
   it('should display an error notification if fetching docker images fails', async () => {

--- a/src/components/nodeImages/CustomImageModal.tsx
+++ b/src/components/nodeImages/CustomImageModal.tsx
@@ -6,6 +6,7 @@ import { NodeImplementation } from 'shared/types';
 import { useStoreActions } from 'store';
 import { CustomImage } from 'types';
 import { dockerConfigs } from 'utils/constants';
+import { getPolarPlatform } from 'utils/system';
 import DockerImageInput from 'components/common/form/DockerImageInput';
 import { CommandVariables } from './';
 
@@ -48,8 +49,10 @@ const CustomImageModal: React.FC<Props> = ({ image, onClose }) => {
     form.setFieldsValue({ command: dockerConfigs[value].command });
   };
 
+  const platform = getPolarPlatform();
+  const lnImpls: NodeImplementation[] = ['LND', 'c-lightning', 'eclair'];
   const implGroups: Record<string, NodeImplementation[]> = {
-    Lightning: ['LND', 'c-lightning', 'eclair'],
+    Lightning: lnImpls.filter(i => dockerConfigs[i].platforms.includes(platform)),
     Bitcoin: ['bitcoind'],
   };
 

--- a/src/components/nodeImages/CustomImageModal.tsx
+++ b/src/components/nodeImages/CustomImageModal.tsx
@@ -49,7 +49,7 @@ const CustomImageModal: React.FC<Props> = ({ image, onClose }) => {
   };
 
   const implGroups: Record<string, NodeImplementation[]> = {
-    Lightning: ['LND', 'c-lightning'],
+    Lightning: ['LND', 'c-lightning', 'eclair'],
     Bitcoin: ['bitcoind'],
   };
 

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -355,6 +355,7 @@
   "store.models.network.removeCompatErr": "There are no other compatible backends for {{lnName}} to connect to. You must remove the {{lnName}} node first",
   "store.models.network.exportTitle": "Export '{{name}}'",
   "store.models.network.exportBadStatus": "The network must be stopped to be exported",
+  "store.models.network.missingImages": "Cannot start the network because it contains custom node images that are not available on this machine",
   "utils.network.backendCompatError": "This network does not contain a Bitcoin Core v{{requiredVersion}} (or lower) node which is required for {{implementation}} v{{version}}",
   "utils.network.incompatibleImplementation": "Importing networks with {{implementation}} nodes is not supported on {{platform}}",
   "utils.network.unknownImplementation": "Cannot import unknown Lightning implementation '{{implementation}}'"

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -113,6 +113,7 @@
   "cmps.designer.link.CloseChannelButton.cancelBtn": "Cancel",
   "cmps.designer.link.CloseChannelButton.success": "The channel has been closed",
   "cmps.designer.link.CloseChannelButton.error": "Unable to close the channel",
+  "cmps.designer.link.CloseChannelButton.notStarted": "The source node must be Started",
   "cmps.designer.link.LinkDetails.invalidTitle": "Invalid Selection",
   "cmps.designer.link.LinkDetails.invalidMsg": "You've somehow managed to select an invalid link. Click the reload icon above to ensure your chart accurately represents the state in your nodes",
   "cmps.designer.link.Peer.title": "Bitcoin Peer Connection",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -30,6 +30,26 @@ const Root: React.FC = () => (
           width: 100vw;
           height: 100vh;
         }
+
+        ::-webkit-scrollbar {
+          width: 8px;
+          background-color: rgba(0, 0, 0, 0);
+          border-radius: 10px;
+        }
+
+        ::-webkit-scrollbar:hover {
+          background-color: rgba(0, 0, 0, 0.1);
+        }
+
+        ::-webkit-scrollbar-thumb:vertical {
+          background-color: rgba(0, 0, 0, 0.2);
+          border-radius: 10px;
+        }
+
+        ::-webkit-scrollbar-thumb:vertical:active {
+          background-color: rgba(0, 0, 0, 0.6);
+          border-radius: 10px;
+        }
       `}
     />
     <App />

--- a/src/store/models/bitcoind.ts
+++ b/src/store/models/bitcoind.ts
@@ -73,7 +73,7 @@ const bitcoindModel: BitcoindModel = {
     if (node.name === 'backend1') {
       // only mine this block on the first node
       const { chainInfo } = getState().nodes['backend1'];
-      if (chainInfo && chainInfo.blocks === 0) {
+      if (chainInfo) {
         await injections.bitcoindService.mine(1, node);
         await actions.getInfo(node);
       }

--- a/src/store/models/network.spec.ts
+++ b/src/store/models/network.spec.ts
@@ -618,6 +618,16 @@ describe('Network model', () => {
       });
       expect(logMock.info).toBeCalledWith('Failed to connect all LN peers', err);
     });
+
+    it('should throw an error if a custom node image is missing', async () => {
+      const { networks } = store.getState().network;
+      networks[0].nodes.lightning[0].docker.image = 'custom-image:latest';
+      store.getActions().network.setNetworks(networks);
+      const { start } = store.getActions().network;
+      const errMsg =
+        'Cannot start the network because it contains custom node images that are not available on this machine: custom-image:latest';
+      await expect(start(firstNetwork().id)).rejects.toThrow(errMsg);
+    });
   });
 
   describe('Stopping', () => {


### PR DESCRIPTION
This PR contains multiple fixes for issues found when testing on all platforms (Mac, Windows and Linux).

- view logs shows infinite loader (linux)
- don't show incompatible custom nodes in the new image modal (windows)
- don't show incompatible custom nodes in the NewNetwork screen (windows)
- add eclair to the custom node dropdown
- for eclair to start successfully, always mine 1 block when the network is started
- do not allow importing networks with missing images
- in NewNetwork, change custom nodes row to 4 columns
- prevent close channel for stopped node
- use styled scrollbars throughout the whole app