### PR TITLE
fix(lnd): add docker container name as tlsextradomain

### DIFF
--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -281,6 +281,7 @@
   "cmps.nodeImages.CommandVariables.variable": "Variable",
   "cmps.nodeImages.CommandVariables.desc": "Description",
   "cmps.nodeImages.CommandVariables.var-name": "The generated name of the node (ex: alice)",
+  "cmps.nodeImages.CommandVariables.var-containerName": "The generated name of the docker container (ex: polar-n1-alice)",
   "cmps.nodeImages.CommandVariables.var-backendName": "The generated name of the Bitcoin node that the Lightning node uses as a backend (ex: backend1)",
   "cmps.nodeImages.CommandVariables.var-rpcUser": "The RPC username used to authenticate to the backend Bitcoin node",
   "cmps.nodeImages.CommandVariables.var-rpcPass": "The RPC password used to authenticate to the backend Bitcoin node",

--- a/src/lib/docker/composeFile.ts
+++ b/src/lib/docker/composeFile.ts
@@ -72,6 +72,7 @@ class ComposeFile {
     // define the variable substitutions
     const variables = {
       name: node.name,
+      containerName: container,
       backendName: getContainerName(backend),
       rpcUser: bitcoinCredentials.user,
       rpcPass: bitcoinCredentials.pass,

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -90,6 +90,7 @@ export const dockerConfigs: Record<NodeImplementation, DockerConfig> = {
       '--alias={{name}}',
       '--externalip={{name}}',
       '--tlsextradomain={{name}}',
+      '--tlsextradomain={{containerName}}',
       '--listen=0.0.0.0:9735',
       '--rpclisten=0.0.0.0:10009',
       '--restlisten=0.0.0.0:8080',
@@ -103,7 +104,7 @@ export const dockerConfigs: Record<NodeImplementation, DockerConfig> = {
       '--bitcoind.zmqpubrawtx=tcp://{{backendName}}:28335',
     ].join('\n  '),
     // if vars are modified, also update composeFile.ts & the i18n strings for cmps.nodes.CommandVariables
-    variables: ['name', 'backendName', 'rpcUser', 'rpcPass'],
+    variables: ['name', 'containerName', 'backendName', 'rpcUser', 'rpcPass'],
   },
   'c-lightning': {
     name: 'c-lightning',


### PR DESCRIPTION
Closes #352

Adds the LND node's docker container name as a `--tlsextradomain` command line argument to support RPC connections from external docker networks.
