### PR TITLE
feat(bitcoind): expose Bitcoin Core P2P port

### DIFF
--- a/src/components/designer/bitcoind/ConnectTab.tsx
+++ b/src/components/designer/bitcoind/ConnectTab.tsx
@@ -37,6 +37,7 @@ const ConnectTab: React.FC<Props> = ({ node }) => {
 
   const details: DetailValues = [
     { label: l('rpcHost'), value: `http://127.0.0.1:${node.ports.rpc}` },
+    { label: l('p2pHost'), value: `tcp://127.0.0.1:${node.ports.p2p}` },
     { label: l('zmqBlockHost'), value: `tcp://127.0.0.1:${node.ports.zmqBlock}` },
     { label: l('zmqTxHost'), value: `tcp://127.0.0.1:${node.ports.zmqTx}` },
     { label: l('rpcUser'), value: bitcoinCredentials.user },

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -50,6 +50,7 @@
   "cmps.designer.bitcoind.BitcoinDetails.waitingNotice": "Waiting for bitcoind to come online",
   "cmps.designer.bitcoind.BitcoinDetails.getInfoErr": "Unable to connect to node",
   "cmps.designer.bitcoind.ConnectTab.rpcHost": "RPC Host",
+  "cmps.designer.bitcoind.ConnectTab.p2pHost": "P2P Host",
   "cmps.designer.bitcoind.ConnectTab.zmqBlockHost": "ZMQ Block Host",
   "cmps.designer.bitcoind.ConnectTab.zmqTxHost": "ZMQ Transaction Host",
   "cmps.designer.bitcoind.ConnectTab.rpcUser": "Username",

--- a/src/lib/docker/composeFile.ts
+++ b/src/lib/docker/composeFile.ts
@@ -40,7 +40,7 @@ class ComposeFile {
 
   addBitcoind(node: BitcoinNode) {
     const { name, version, ports } = node;
-    const { rpc, zmqBlock, zmqTx } = ports;
+    const { rpc, p2p, zmqBlock, zmqTx } = ports;
     const container = getContainerName(node);
     // define the variable substitutions
     const variables = {
@@ -59,6 +59,7 @@ class ComposeFile {
       container,
       image,
       rpc,
+      p2p,
       zmqBlock,
       zmqTx,
       command,

--- a/src/lib/docker/nodeTemplates.spec.ts
+++ b/src/lib/docker/nodeTemplates.spec.ts
@@ -7,6 +7,7 @@ describe('nodeTemplates', () => {
       'polar-mynode',
       'bitcoind:v0.8.0',
       18443,
+      19444,
       28334,
       29335,
       '',

--- a/src/lib/docker/nodeTemplates.ts
+++ b/src/lib/docker/nodeTemplates.ts
@@ -10,6 +10,7 @@ export const bitcoind = (
   container: string,
   image: string,
   rpcPort: number,
+  p2pPort: number,
   zmqBlockPort: number,
   zmqTxPort: number,
   command: string,
@@ -33,6 +34,7 @@ export const bitcoind = (
   ],
   ports: [
     `${rpcPort}:18443`, // RPC
+    `${p2pPort}:18444`, // P2P
     `${zmqBlockPort}:28334`, // ZMQ blocks
     `${zmqTxPort}:28335`, // ZMQ txns
   ],

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -63,6 +63,7 @@ export interface BitcoinNode extends CommonNode {
   peers: string[];
   ports: {
     rpc: number;
+    p2p: number;
     zmqBlock: number;
     zmqTx: number;
   };

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -46,6 +46,7 @@ export const denominationNames: { [key in Denomination]: string } = {
 export const BasePorts: Record<NodeImplementation, Record<string, number>> = {
   bitcoind: {
     rest: 18443,
+    p2p: 19444,
     zmqBlock: 28334,
     zmqTx: 29335,
   },

--- a/src/utils/network.spec.ts
+++ b/src/utils/network.spec.ts
@@ -48,11 +48,13 @@ describe('Network Utils', () => {
       mockDetectPort.mockImplementation(port => Promise.resolve(port + 1));
       network.nodes.lightning = [];
       const restPort = network.nodes.bitcoin[0].ports.rpc;
+      const p2pPort = network.nodes.bitcoin[0].ports.p2p;
       const zmqBlockPort = network.nodes.bitcoin[0].ports.zmqBlock;
       const zmqTxPort = network.nodes.bitcoin[0].ports.zmqTx;
       const ports = (await getOpenPorts(network)) as OpenPorts;
       expect(ports).toBeDefined();
       expect(ports[network.nodes.bitcoin[0].name].rpc).toBe(restPort + 1);
+      expect(ports[network.nodes.bitcoin[0].name].p2p).toBe(p2pPort + 1);
       expect(ports[network.nodes.bitcoin[0].name].zmqBlock).toBe(zmqBlockPort + 1);
       expect(ports[network.nodes.bitcoin[0].name].zmqTx).toBe(zmqTxPort + 1);
     });
@@ -67,6 +69,20 @@ describe('Network Utils', () => {
       const ports = (await getOpenPorts(network)) as OpenPorts;
       expect(ports).toBeDefined();
       expect(ports[network.nodes.bitcoin[0].name].rpc).toBe(restPort + 1);
+      expect(ports[network.nodes.bitcoin[0].name].zmqBlock).toBeUndefined();
+      expect(ports[network.nodes.bitcoin[0].name].zmqTx).toBeUndefined();
+    });
+
+    it('should update the p2p port for bitcoind', async () => {
+      const portsInUse = [19444];
+      mockDetectPort.mockImplementation(port =>
+        Promise.resolve(portsInUse.includes(port) ? port + 1 : port),
+      );
+      network.nodes.lightning = [];
+      const p2pPort = network.nodes.bitcoin[0].ports.p2p;
+      const ports = (await getOpenPorts(network)) as OpenPorts;
+      expect(ports).toBeDefined();
+      expect(ports[network.nodes.bitcoin[0].name].p2p).toBe(p2pPort + 1);
       expect(ports[network.nodes.bitcoin[0].name].zmqBlock).toBeUndefined();
       expect(ports[network.nodes.bitcoin[0].name].zmqTx).toBeUndefined();
     });

--- a/src/utils/network.ts
+++ b/src/utils/network.ts
@@ -240,6 +240,7 @@ export const createBitcoindNetworkNode = (
     status,
     ports: {
       rpc: BasePorts.bitcoind.rest + id,
+      p2p: BasePorts.bitcoind.p2p + id,
       zmqBlock: BasePorts.bitcoind.zmqBlock + id,
       zmqTx: BasePorts.bitcoind.zmqTx + id,
     },
@@ -445,6 +446,17 @@ export const getOpenPorts = async (network: Network): Promise<OpenPorts | undefi
     if (openPorts.join() !== existingPorts.join()) {
       openPorts.forEach((port, index) => {
         ports[bitcoin[index].name] = { rpc: port };
+      });
+    }
+
+    existingPorts = bitcoin.map(n => n.ports.p2p);
+    openPorts = await getOpenPortRange(existingPorts);
+    if (openPorts.join() !== existingPorts.join()) {
+      openPorts.forEach((port, index) => {
+        ports[bitcoin[index].name] = {
+          ...(ports[bitcoin[index].name] || {}),
+          p2p: port,
+        };
       });
     }
 


### PR DESCRIPTION
Closes #370 

### Description

Exposes the Bitcoin Core P2P port on the host to allow other applications on the local network to join the Polar Bitcoin network.

### Steps to Test

1. Create a Polar network with a Bitcoin node
2. Copy the P2P connection string
3. Run `bitcoin-cli addnode <connection string> onetry` on a regtest node on the local network
4. Run `bitcoin-cli getpeerinfo` on the local network node to verify you are connected

### Screenshots
<img width="385" alt="Screenshot 2020-08-21 at 01 48 12" src="https://user-images.githubusercontent.com/2123375/90812853-efe6f180-e350-11ea-928e-27b97e6d610c.png">
