### PR TITLE
feat(chart): add zoom buttons to the designer

### DIFF
--- a/src/components/designer/NetworkDesigner.spec.tsx
+++ b/src/components/designer/NetworkDesigner.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { IChart } from '@mrblenny/react-flow-chart';
-import { fireEvent, waitForElementToBeRemoved } from '@testing-library/dom';
+import { fireEvent, waitFor, waitForElementToBeRemoved } from '@testing-library/dom';
 import { act } from '@testing-library/react';
 import { themeColors } from 'theme/colors';
 import { initChartFromNetwork } from 'utils/chart';
@@ -90,11 +90,26 @@ describe('NetworkDesigner Component', () => {
     expect(await findByText('backend1')).toBeInTheDocument();
     expect(queryByText('Node Type')).not.toBeInTheDocument();
     // click the bitcoind node in the chart
-    act(() => {
-      fireEvent.click(getByText('backend1'));
-    });
+    fireEvent.click(getByText('backend1'));
     // ensure text from the sidebar is visible
     expect(await findByText('Node Type')).toBeInTheDocument();
+  });
+
+  it('should update the redux state when zoom buttons are clicked', async () => {
+    const { getByLabelText, store } = renderComponent();
+    expect(store.getState().designer.activeChart.scale).toBe(1);
+    fireEvent.click(getByLabelText('zoom-in'));
+    expect(store.getState().designer.activeChart.scale).toBe(1.1);
+    fireEvent.click(getByLabelText('fullscreen'));
+    expect(store.getState().designer.activeChart.scale).toBe(1.0);
+    await waitFor(() =>
+      expect(getByLabelText('fullscreen').parentElement).toBeDisabled(),
+    );
+    fireEvent.click(getByLabelText('zoom-out'));
+    expect(store.getState().designer.activeChart.scale).toBe(0.9);
+    await waitFor(() =>
+      expect(getByLabelText('fullscreen').parentElement).not.toBeDisabled(),
+    );
   });
 
   it('should display the OpenChannel modal', async () => {

--- a/src/components/designer/NetworkDesigner.tsx
+++ b/src/components/designer/NetworkDesigner.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect } from 'react';
+import { FullscreenOutlined, ZoomInOutlined, ZoomOutOutlined } from '@ant-design/icons';
 import styled from '@emotion/styled';
 import { FlowChart } from '@mrblenny/react-flow-chart';
+import { Button } from 'antd';
 import { useDebounce } from 'hooks';
 import { useTheme } from 'hooks/useTheme';
 import { useStoreActions, useStoreState } from 'store';
@@ -26,6 +28,11 @@ const Styled = {
   FlowChart: styled(FlowChart)`
     height: 100%;
   `,
+  ZoomButtons: styled(Button.Group)`
+    position: absolute;
+    bottom: 16px;
+    right: 390px;
+  `,
 };
 
 interface Props {
@@ -35,7 +42,7 @@ interface Props {
 
 const NetworkDesigner: React.FC<Props> = ({ network, updateStateDelay = 3000 }) => {
   const theme = useTheme();
-  const callbacks = useStoreActions(s => s.designer);
+  const { zoomIn, zoomOut, zoomReset, ...callbacks } = useStoreActions(s => s.designer);
   const {
     openChannel,
     createInvoice,
@@ -69,6 +76,15 @@ const NetworkDesigner: React.FC<Props> = ({ network, updateStateDelay = 3000 }) 
         }}
         callbacks={callbacks}
       />
+      <Styled.ZoomButtons>
+        <Button icon={<ZoomInOutlined />} onClick={zoomIn} />
+        <Button icon={<ZoomOutOutlined />} onClick={zoomOut} />
+        <Button
+          icon={<FullscreenOutlined />}
+          onClick={zoomReset}
+          disabled={chart.scale === 1}
+        />
+      </Styled.ZoomButtons>
       <Sidebar network={network} chart={chart} />
       {openChannel.visible && <OpenChannelModal network={network} />}
       {createInvoice.visible && <CreateInvoiceModal network={network} />}

--- a/src/store/models/designer.spec.ts
+++ b/src/store/models/designer.spec.ts
@@ -679,7 +679,7 @@ describe('Designer model', () => {
         const { onZoomCanvas } = store.getActions().designer;
         const data = { positionX: 100, positionY: 100, zoom: 0.5, scale: 2 };
         onZoomCanvas({ data } as any);
-        expect(firstChart().offset).toEqual({ x: 200, y: 200 });
+        expect(firstChart().offset).toEqual({ x: 100, y: 100 });
         expect(firstChart().scale).toEqual(2);
       });
     });

--- a/src/utils/chart.ts
+++ b/src/utils/chart.ts
@@ -28,7 +28,7 @@ export const rotate = (
   return { x, y };
 };
 
-export const snap = (position: IPosition, config?: IConfig, zoom = 1) => {
+export const snap = (position: IPosition, config?: IConfig) => {
   let offset = { x: position.x, y: position.y };
   if (config && config.snapToGrid) {
     offset = {
@@ -36,11 +36,6 @@ export const snap = (position: IPosition, config?: IConfig, zoom = 1) => {
       y: Math.round(position.y / 20) * 20,
     };
   }
-
-  // factor in the zoom level
-  offset.x = offset.x / zoom;
-  offset.y = offset.y / zoom;
-
   return offset;
 };
 


### PR DESCRIPTION
### Description

Add the ability to zoom in & out the designer and nodes to more easily visualize the network. 

### Steps to Test

1. Click on a network
1. Click on the zoom icons on the bottom right of the canvas
1. Use the mouse wheel scroll to also adjust the zoom level
1. Drag a new node onto the canvas to ensure proper placement

### Screenshots

![image](https://user-images.githubusercontent.com/1356600/92068978-46532780-ed76-11ea-9daa-40806c314b61.png)

