### PR TITLE
fix(lnd): fixes clipboard copy value for p2pLnUrlInternal

### DIFF
--- a/src/components/designer/lightning/ConnectTab.tsx
+++ b/src/components/designer/lightning/ConnectTab.tsx
@@ -129,7 +129,7 @@ const ConnectTab: React.FC<Props> = ({ node }) => {
   const hosts: DetailValues = [
     [l('grpcHost'), grpcUrl, grpcUrl],
     [l('restHost'), restUrl, restUrl],
-    [l('p2pLnUrlInternal'), info.p2pUriExternal, ellipseInner(p2pLnUrlInternal, 3, 17)],
+    [l('p2pLnUrlInternal'), p2pLnUrlInternal, ellipseInner(p2pLnUrlInternal, 3, 17)],
     [
       l('p2pLnUrlExternal'),
       info.p2pUriExternal,


### PR DESCRIPTION
### Description
Copying the `P2P Internal` value to the clipboard was copying the value for `P2P External` instead.

### Steps to Test

1. Setup a network
2. Copy the value for `P2P Internal`
3. Paste the value somewhere (should match the displayed value in the app)
