### PR TITLE
fix(lnd): correct REST url

### DIFF
--- a/src/components/designer/lightning/ConnectTab.tsx
+++ b/src/components/designer/lightning/ConnectTab.tsx
@@ -67,7 +67,7 @@ const ConnectTab: React.FC<Props> = ({ node }) => {
         const lnd = node as LndNode;
         return {
           restUrl: `https://127.0.0.1:${lnd.ports.rest}`,
-          restDocsUrl: 'https://api.lightning.community/rest/',
+          restDocsUrl: 'https://api.lightning.community/#lnd-rest-api-reference',
           grpcUrl: `127.0.0.1:${lnd.ports.grpc}`,
           grpcDocsUrl: 'https://api.lightning.community/',
           credentials: {

--- a/src/components/designer/lightning/LightningDetails.spec.tsx
+++ b/src/components/designer/lightning/LightningDetails.spec.tsx
@@ -241,7 +241,7 @@ describe('LightningDetails', () => {
       fireEvent.click(getByText('REST'));
       await waitFor(() => {
         expect(shell.openExternal).toBeCalledWith(
-          'https://api.lightning.community/rest/',
+          'https://api.lightning.community/#lnd-rest-api-reference',
         );
       });
     });


### PR DESCRIPTION
Closes #(issue number goes here)

### Description

The current LND [REST](https://api.lightning.community/rest) URL looks stale, so updating it to https://api.lightning.community/#lnd-rest-api-reference

### Steps to Test

Click on the REST link for an LND node

### Screenshots

![image](https://user-images.githubusercontent.com/708562/101764638-47e76680-3aae-11eb-8b7d-3b8440566d04.png)

