### PR TITLE
feat(bitcoind): expose REST interface by default

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -184,6 +184,7 @@ export const dockerConfigs: Record<NodeImplementation, DockerConfig> = {
       '-rpcbind=0.0.0.0',
       '-rpcallowip=0.0.0.0/0',
       '-rpcport=18443',
+      '-rest',
       '-listen=1',
       '-listenonion=0',
       '-fallbackfee=0.0002',


### PR DESCRIPTION
Closes #(issue number goes here)

### Description
Exposes bitcoind's REST interface by default. No prob if this idea has been considered then discarded for any reason, feel free to close. Thank you!

### Steps to Test

Attempt to connect to bitcoind over REST on startup.
