### PR TITLE
fix(nodes): increase node startup timeout from 60 to 120 secs

### DIFF
--- a/src/lib/bitcoin/bitcoindService.ts
+++ b/src/lib/bitcoin/bitcoindService.ts
@@ -85,7 +85,7 @@ class BitcoindService implements BitcoindLibrary {
   async waitUntilOnline(
     node: BitcoinNode,
     interval = 3 * 1000, // check every 3 seconds
-    timeout = 60 * 1000, // timeout after 60 seconds
+    timeout = 120 * 1000, // timeout after 120 seconds
   ): Promise<void> {
     return waitFor(
       async () => {

--- a/src/lib/lightning/clightning/clightningService.ts
+++ b/src/lib/lightning/clightning/clightningService.ts
@@ -180,7 +180,7 @@ class CLightningService implements LightningService {
   async waitUntilOnline(
     node: LightningNode,
     interval = 3 * 1000, // check every 3 seconds
-    timeout = 60 * 1000, // timeout after 60 seconds
+    timeout = 120 * 1000, // timeout after 120 seconds
   ): Promise<void> {
     return waitFor(
       async () => {

--- a/src/lib/lightning/eclair/eclairService.ts
+++ b/src/lib/lightning/eclair/eclairService.ts
@@ -208,7 +208,7 @@ class EclairService implements LightningService {
   async waitUntilOnline(
     node: LightningNode,
     interval = 3 * 1000, // check every 3 seconds
-    timeout = 60 * 1000, // timeout after 60 seconds
+    timeout = 120 * 1000, // timeout after 120 seconds
   ): Promise<void> {
     return waitFor(
       async () => {

--- a/src/lib/lightning/lnd/lndService.ts
+++ b/src/lib/lightning/lnd/lndService.ts
@@ -159,7 +159,7 @@ class LndService implements LightningService {
   async waitUntilOnline(
     node: LightningNode,
     interval = 3 * 1000, // check every 3 seconds
-    timeout = 60 * 1000, // timeout after 60 seconds
+    timeout = 120 * 1000, // timeout after 120 seconds
   ): Promise<void> {
     return waitFor(
       async () => {


### PR DESCRIPTION
Closes #464 

This PR just increases the node startup timeout to accomodate for systems with slower Docker performance.

