### PR TITLE
Upgrade nodejs to v14

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,6 +124,8 @@ If you would like to fix a bug or implement a new feature, here are the recommen
       style:       Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
       refactor:    A code change that neither fixes a bug nor adds a feature
       perf:        A code change that improves performance
+      refactor:    A code change that neither fixes a bug nor adds a feature
+      perf:        A code change that improves performance
       test:        Adding missing tests or correcting existing tests
       build:       Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
       ci:          Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,8 +124,6 @@ If you would like to fix a bug or implement a new feature, here are the recommen
       style:       Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
       refactor:    A code change that neither fixes a bug nor adds a feature
       perf:        A code change that improves performance
-      refactor:    A code change that neither fixes a bug nor adds a feature
-      perf:        A code change that improves performance
       test:        Adding missing tests or correcting existing tests
       build:       Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
       ci:          Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)

--- a/docker/clightning/Dockerfile
+++ b/docker/clightning/Dockerfile
@@ -168,7 +168,7 @@ COPY --from=builder /opt/lightningd/contrib/lightning-cli.bash-completion /etc/b
 # install nodejs
 RUN apt-get update -y \
   && apt-get install -y curl gosu git \
-  && curl -sL https://deb.nodesource.com/setup_12.x | bash - \
+  && curl -sL https://deb.nodesource.com/setup_14.x | bash - \
   && apt-get install -y nodejs \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
### Description

Updates nodejs in the Dockerfile from v12 (unsupported) to v14 (lts). Tested and it's working.

Once this is merged, you could do this to publish the new v0.11.2 image:

```
docker build --build-arg CLN_VERSION=0.11.2 -t polarlightning/clightning:0.11.2 .
docker push polarlightning/clightning:0.11.2
```