### PR TITLE
fix(home): fix loading animation on home screen

### DIFF
--- a/src/components/common/Loader.spec.tsx
+++ b/src/components/common/Loader.spec.tsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react';
 import Loader from './Loader';
 
 describe('Loader Component', () => {
-  const renderComponent = (inline?: boolean, size?: string) => {
+  const renderComponent = (inline?: boolean, size?: number) => {
     const result = render(<Loader inline={inline} size={size} />);
     return {
       ...result,
@@ -17,7 +17,8 @@ describe('Loader Component', () => {
     expect(loader).toHaveStyle(`position: absolute;`);
     expect(loader).toHaveStyle(`top: 50%;`);
     expect(loader).toHaveStyle(`left: 50%;`);
-    expect(loader).toHaveStyle(`transform: translate(-50%, -50%);`);
+    expect(loader).toHaveStyle(`margin-top: -1rem;`);
+    expect(loader).toHaveStyle(`margin-left: -1rem;`);
   });
 
   it('should render inline', () => {
@@ -25,11 +26,12 @@ describe('Loader Component', () => {
     expect(loader).not.toHaveStyle(`position: absolute;`);
     expect(loader).not.toHaveStyle(`top: 50%;`);
     expect(loader).not.toHaveStyle(`left: 50%;`);
-    expect(loader).not.toHaveStyle(`transform: translate(-50%, -50%);`);
+    expect(loader).not.toHaveStyle(`margin-top: -1rem;`);
+    expect(loader).not.toHaveStyle(`margin-left: -1rem;`);
   });
 
   it('should use the correct size', () => {
-    const { loader } = renderComponent(false, '3rem');
+    const { loader } = renderComponent(false, 3);
     expect(loader).toHaveStyle(`font-size: 3rem;`);
   });
 });

--- a/src/components/common/Loader.tsx
+++ b/src/components/common/Loader.tsx
@@ -3,20 +3,29 @@ import { LoadingOutlined } from '@ant-design/icons';
 
 interface Props {
   inline?: boolean;
-  size?: string;
+  /** the font size of the icon (in rem units) */
+  size?: number;
 }
 
-const Loader: React.FC<Props> = ({ inline, size }) => (
-  <LoadingOutlined
-    style={{
-      color: '#ffa940',
-      fontSize: size || '2rem',
-      position: inline ? undefined : 'absolute',
-      top: inline ? undefined : '50%',
-      left: inline ? undefined : '50%',
-      transform: inline ? undefined : 'translate(-50%, -50%)',
-    }}
-  />
-);
+const Loader: React.FC<Props> = ({ inline, size = 2 }) => {
+  const absStyles: React.CSSProperties = inline
+    ? {}
+    : {
+        position: 'absolute',
+        top: '50%',
+        left: '50%',
+        marginTop: `-${size / 2}rem`,
+        marginLeft: `-${size / 2}rem`,
+      };
+  return (
+    <LoadingOutlined
+      style={{
+        color: '#ffa940',
+        fontSize: `${size}rem`,
+        ...absStyles,
+      }}
+    />
+  );
+};
 
 export default Loader;

--- a/src/components/designer/custom/NodeInner.tsx
+++ b/src/components/designer/custom/NodeInner.tsx
@@ -30,7 +30,7 @@ const CustomNodeInner: React.FC<INodeInnerDefaultProps> = ({ node }) => {
 
   return node.id === LOADING_NODE_ID ? (
     <Styled.Node size={node.size} colors={theme.node}>
-      <Loader size="16px" />
+      <Loader size={1} />
     </Styled.Node>
   ) : (
     <NodeContextMenu node={node}>


### PR DESCRIPTION
This PR fixes a minor CSS issue where the loading icon on the home screen did not animate in a full circle.