### PR TITLE
fix(network): add error handling when creating a new network

### DIFF
--- a/src/components/network/NewNetwork.spec.tsx
+++ b/src/components/network/NewNetwork.spec.tsx
@@ -2,13 +2,16 @@ import React from 'react';
 import { fireEvent, waitFor } from '@testing-library/react';
 import os from 'os';
 import { CustomImage } from 'types';
-import { renderWithProviders, suppressConsoleErrors } from 'utils/tests';
+import { injections, renderWithProviders, suppressConsoleErrors } from 'utils/tests';
 import { HOME, NETWORK_VIEW } from 'components/routing';
 import NewNetwork from './NewNetwork';
 
 jest.mock('os');
 
 const mockOS = os as jest.Mocked<typeof os>;
+const mockDockerService = injections.dockerService as jest.Mocked<
+  typeof injections.dockerService
+>;
 
 describe('NewNetwork component', () => {
   const customImages: CustomImage[] = [
@@ -103,6 +106,15 @@ describe('NewNetwork component', () => {
       await waitFor(() => {
         expect(injections.dockerService.saveComposeFile).toBeCalled();
       });
+    });
+
+    it('should display an error if the submission fails', async () => {
+      mockDockerService.saveComposeFile.mockRejectedValue(new Error('asdf'));
+      const { createBtn, nameInput, findByText } = renderComponent();
+      fireEvent.change(nameInput, { target: { value: 'test' } });
+      fireEvent.click(createBtn);
+      expect(await findByText('Unable to create the new network')).toBeInTheDocument();
+      expect(await findByText('asdf')).toBeInTheDocument();
     });
   });
 });

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -288,6 +288,7 @@
   "cmps.network.NewNetwork.managedLabel": "How many Managed Nodes?",
   "cmps.network.NewNetwork.clightningWindows": "Not supported on Windows yet.",
   "cmps.network.NewNetwork.btnCreate": "Create Network",
+  "cmps.network.NewNetwork.createError": "Unable to create the new network",
   "cmps.nodeImages.CommandVariables.header": "Command Variable Substitutions",
   "cmps.nodeImages.CommandVariables.tableTitle": "Wrap the variables below in double braces to use them in the command",
   "cmps.nodeImages.CommandVariables.variable": "Variable",


### PR DESCRIPTION
This PR adds proper error handling when creating a new network. It will now display an error toast message with more information as to why the creation failed. This should help diagnose the problem in #569.
