### PR TITLE
feat(designer): move sync button to actions toolbar

### DIFF
--- a/src/components/designer/Sidebar.tsx
+++ b/src/components/designer/Sidebar.tsx
@@ -29,7 +29,7 @@ const Sidebar: React.FC<Props> = ({ network, chart }) => {
       return <LinkDetails link={link} network={network} />;
     }
 
-    return <DefaultSidebar network={network} />;
+    return <DefaultSidebar />;
   }, [network, chart.selected, chart.links]);
 
   return <>{cmp}</>;

--- a/src/components/designer/SyncButton.tsx
+++ b/src/components/designer/SyncButton.tsx
@@ -1,11 +1,17 @@
 import React from 'react';
 import { useAsyncCallback } from 'react-async-hook';
 import { ReloadOutlined } from '@ant-design/icons';
+import styled from '@emotion/styled';
 import { Button, Tooltip } from 'antd';
 import { usePrefixedTranslation } from 'hooks';
-import { Status } from 'shared/types';
 import { useStoreActions } from 'store';
 import { Network } from 'types';
+
+const Styled = {
+  Button: styled(Button)`
+    margin-left: 8px;
+  `,
+};
 
 interface Props {
   network: Network;
@@ -30,9 +36,8 @@ const SyncButton: React.FC<Props> = ({ network }) => {
   });
   return (
     <Tooltip title={l('syncBtnTip')}>
-      <Button
+      <Styled.Button
         icon={<ReloadOutlined />}
-        disabled={network.status !== Status.Started}
         onClick={syncChartAsync.execute}
         loading={syncChartAsync.loading}
       />

--- a/src/components/designer/default/DefaultSidebar.spec.tsx
+++ b/src/components/designer/default/DefaultSidebar.spec.tsx
@@ -6,14 +6,7 @@ import { Status } from 'shared/types';
 import { CustomImage } from 'types';
 import { initChartFromNetwork } from 'utils/chart';
 import { defaultRepoState } from 'utils/constants';
-import {
-  defaultStateBalances,
-  defaultStateInfo,
-  getNetwork,
-  injections,
-  lightningServiceMock,
-  renderWithProviders,
-} from 'utils/tests';
+import { getNetwork, injections, renderWithProviders } from 'utils/tests';
 import DefaultSidebar from './DefaultSidebar';
 
 jest.mock('os', () => {
@@ -65,7 +58,7 @@ describe('DefaultSidebar Component', () => {
       },
     };
 
-    const result = renderWithProviders(<DefaultSidebar network={network} />, {
+    const result = renderWithProviders(<DefaultSidebar />, {
       initialState,
     });
     return {
@@ -137,29 +130,5 @@ describe('DefaultSidebar Component', () => {
       REACT_FLOW_CHART,
       JSON.stringify({ type: 'LND', version: lndLatest }),
     );
-  });
-
-  describe('Sync Chart button', () => {
-    it('should display an error if syncing the chart fails', async () => {
-      lightningServiceMock.getInfo.mockRejectedValue(new Error('failed to get info'));
-      const { getByLabelText, findByText } = renderComponent(Status.Started);
-      fireEvent.click(getByLabelText('reload'));
-      expect(await findByText('failed to get info')).toBeInTheDocument();
-      expect(lightningServiceMock.getInfo).toBeCalledTimes(4);
-    });
-
-    it('should sync the chart from LND nodes', async () => {
-      lightningServiceMock.getInfo.mockResolvedValue(defaultStateInfo({}));
-      lightningServiceMock.getBalances.mockResolvedValue(defaultStateBalances({}));
-      lightningServiceMock.getChannels.mockResolvedValue([]);
-      const { getByLabelText, findByText } = renderComponent(Status.Started);
-      fireEvent.click(getByLabelText('reload'));
-      expect(
-        await findByText('The designer has been synced with the Lightning nodes'),
-      ).toBeInTheDocument();
-      expect(lightningServiceMock.getInfo).toBeCalledTimes(4);
-      expect(lightningServiceMock.getBalances).toBeCalledTimes(4);
-      expect(lightningServiceMock.getChannels).toBeCalledTimes(4);
-    });
   });
 });

--- a/src/components/designer/default/DefaultSidebar.tsx
+++ b/src/components/designer/default/DefaultSidebar.tsx
@@ -5,11 +5,9 @@ import { Button, Switch } from 'antd';
 import { usePrefixedTranslation } from 'hooks';
 import { NodeImplementation } from 'shared/types';
 import { useStoreActions, useStoreState } from 'store';
-import { Network } from 'types';
 import { dockerConfigs } from 'utils/constants';
 import { getPolarPlatform } from 'utils/system';
 import SidebarCard from '../SidebarCard';
-import SyncButton from '../SyncButton';
 import DraggableNode from './DraggableNode';
 
 const Styled = {
@@ -30,11 +28,7 @@ const Styled = {
   `,
 };
 
-interface Props {
-  network: Network;
-}
-
-const DefaultSidebar: React.FC<Props> = ({ network }) => {
+const DefaultSidebar: React.FC = () => {
   const { l } = usePrefixedTranslation('cmps.designer.default.DefaultSidebar');
 
   const { updateSettings } = useStoreActions(s => s.app);
@@ -82,7 +76,7 @@ const DefaultSidebar: React.FC<Props> = ({ network }) => {
   });
 
   return (
-    <SidebarCard title={l('title')} extra={<SyncButton network={network} />}>
+    <SidebarCard title={l('title')}>
       <p>{l('mainDesc')}</p>
       <Styled.AddNodes>{l('addNodesTitle')}</Styled.AddNodes>
       <Styled.AddDesc>{l('addNodesDesc')}</Styled.AddDesc>

--- a/src/components/network/NetworkActions.tsx
+++ b/src/components/network/NetworkActions.tsx
@@ -17,6 +17,7 @@ import { usePrefixedTranslation } from 'hooks';
 import { Status } from 'shared/types';
 import { useStoreActions, useStoreState } from 'store';
 import { Network } from 'types';
+import SyncButton from 'components/designer/SyncButton';
 
 const Styled = {
   Button: styled(Button)`
@@ -137,6 +138,7 @@ const NetworkActions: React.FC<Props> = ({
           >
             {l('mineBtn')}
           </Button>
+          <SyncButton network={network} />
           <Divider type="vertical" />
         </>
       )}

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -251,7 +251,7 @@
   "cmps.designer.lightning.LightningDetails.connectError": "Unable to connect to {{implementation}} node",
   "cmps.designer.SyncButton.syncSuccess": "The designer has been synced with the Lightning nodes",
   "cmps.designer.SyncButton.syncError": "Failed to sync the network",
-  "cmps.designer.SyncButton.syncBtnTip": "Update channels from nodes",
+  "cmps.designer.SyncButton.syncBtnTip": "Update graph from nodes",
   "cmps.dockerLogs.DockerLogs.connectErr": "Unable to connect to the container",
   "cmps.dockerLogs.ViewLogsButton.title": "Docker Node Logs",
   "cmps.dockerLogs.ViewLogsButton.btn": "View Logs",


### PR DESCRIPTION
### Description

This PR moves the Sync button from the top right of the sidebar to the toolbar next to the Quick Mine button in order to make it visible all the time. I've had discussions with some folks that didn't know this button even existed because it becomes hidden when a node is selected.

### Screenshots

![image](https://user-images.githubusercontent.com/1356600/187587287-e205eeb8-5ac5-431f-91ab-c748b3e496e7.png)
