### PR TITLE
chore(build): add RPM target to releases

### DIFF
--- a/.electronbuildrc
+++ b/.electronbuildrc
@@ -40,6 +40,10 @@
         "arch": ["x64"]
       },
       {
+        "target": "rpm",
+        "arch": ["x64"]
+      },
+      {
         "target": "AppImage",
         "arch": ["x64"]
       }


### PR DESCRIPTION
Closes #564 

### Description

This PR updates the electron builder config to package an RPM file when creating release binaries. 
