### PR TITLE
fix(cln): handle error when funding txid is undefined

### DIFF
--- a/src/lib/lightning/clightning/clightningService.ts
+++ b/src/lib/lightning/clightning/clightningService.ts
@@ -69,7 +69,7 @@ class CLightningService implements LightningService {
           const status = ChannelStateToStatus[c.state];
           return {
             pending: status !== 'Open',
-            uniqueId: c.fundingTxid.slice(-12),
+            uniqueId: c.fundingTxid ? c.fundingTxid.slice(-12) : '',
             channelPoint: c.channelId,
             pubkey: c.id,
             capacity: this.toSats(c.msatoshiTotal),


### PR DESCRIPTION
This PR fixes a minor race condition where sometimes Core Lightning will not return a funding txid immediately after opening a new channels. When this occurs, an error would be displayed in UI. The node would still be fully functional, but this fix just prevents the error from occurring.