### PR TITLE
Missing address flag for announcing externally

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -118,6 +118,7 @@ export const dockerConfigs: Record<NodeImplementation, DockerConfig> = {
       'lightningd',
       '--alias={{name}}',
       '--addr={{name}}',
+      '--addr=0.0.0.0:9735',
       '--network=regtest',
       '--bitcoin-rpcuser={{rpcUser}}',
       '--bitcoin-rpcpassword={{rpcPass}}',


### PR DESCRIPTION
### Description

The missing `--addr=0.0.0.0:9735` causes failure in connecting to core-lightning nodes externally. Polar in the connect tab shows P2P External for core-lightning nodes but it does not work because it's not being announced.

### Steps to Test
1. Try connecting to the p2p external port using telnet, for example `telnet localhost 9836` without the announcing, connection succeeds but terminates instantly.
2. Announce the port, restart the node and try connecting again. Connection persists.

You can also try testing using something like this library https://github.com/jb55/lnsocket/tree/master/examples and commando runes.

