### PR TITLE
fix(deps): change antd Modal visible props to open

### DIFF
--- a/src/components/common/AdvancedOptionsModal.tsx
+++ b/src/components/common/AdvancedOptionsModal.tsx
@@ -43,7 +43,7 @@ const AdvancedOptionsModal: React.FC<Props> = ({ network }) => {
   return (
     <Modal
       title={l('title')}
-      visible={visible}
+      open={visible}
       onCancel={() => hideAdvancedOptions()}
       destroyOnClose
       cancelText={l('cancelBtn')}

--- a/src/components/common/ImageUpdatesModal.tsx
+++ b/src/components/common/ImageUpdatesModal.tsx
@@ -107,7 +107,7 @@ const ImageUpdatesModal: React.FC<Props> = ({ onClose }) => {
       title={l('title')}
       onCancel={onClose}
       destroyOnClose
-      visible
+      open
       width={600}
       centered
       cancelText={l('closeBtn')}

--- a/src/components/common/StatusBadge.tsx
+++ b/src/components/common/StatusBadge.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import styled from '@emotion/styled';
 import { Badge, Tooltip } from 'antd';
 import { Status } from 'shared/types';
 
@@ -20,6 +21,13 @@ const badgeStatuses: BadgeStatus = {
   [Status.Error]: 'error',
 };
 
+const Styled = {
+  Text: styled.span`
+    display: inline-block;
+    margin-left: 8px;
+  `,
+};
+
 const StatusBadge: React.SFC<StatusBadgeProps> = ({ status, text }) => {
   const { t } = useTranslation();
   return (
@@ -27,7 +35,7 @@ const StatusBadge: React.SFC<StatusBadgeProps> = ({ status, text }) => {
       <Tooltip overlay={t(`enums.status.${Status[status]}`)}>
         <Badge status={badgeStatuses[status]} />
       </Tooltip>
-      {text}
+      <Styled.Text>{text}</Styled.Text>
     </>
   );
 };

--- a/src/components/designer/bitcoind/actions/SendOnChainModal.tsx
+++ b/src/components/designer/bitcoind/actions/SendOnChainModal.tsx
@@ -57,7 +57,7 @@ const SendOnChainModal: React.FC<Props> = ({ network }) => {
     <>
       <Modal
         title={l('title')}
-        visible={visible}
+        open={visible}
         onCancel={() => hideSendOnChain()}
         destroyOnClose
         cancelText={l('cancelBtn')}

--- a/src/components/designer/lightning/actions/ChangeBackendModal.tsx
+++ b/src/components/designer/lightning/actions/ChangeBackendModal.tsx
@@ -85,7 +85,7 @@ const ChangeBackendModal: React.FC<Props> = ({ network }) => {
     <>
       <Modal
         title={l('title')}
-        visible={visible}
+        open={visible}
         onCancel={() => hideChangeBackend()}
         destroyOnClose
         cancelText={l('cancelBtn')}

--- a/src/components/designer/lightning/actions/CreateInvoiceModal.tsx
+++ b/src/components/designer/lightning/actions/CreateInvoiceModal.tsx
@@ -111,7 +111,7 @@ const CreateInvoiceModal: React.FC<Props> = ({ network }) => {
     <>
       <Modal
         title={l('title')}
-        visible={visible}
+        open={visible}
         onCancel={() => hideCreateInvoice()}
         destroyOnClose
         footer={invoice ? null : undefined}

--- a/src/components/designer/lightning/actions/OpenChannelModal.tsx
+++ b/src/components/designer/lightning/actions/OpenChannelModal.tsx
@@ -159,7 +159,7 @@ const OpenChannelModal: React.FC<Props> = ({ network }) => {
     <>
       <Modal
         title={l('title')}
-        visible={visible}
+        open={visible}
         onCancel={() => hideOpenChannel()}
         destroyOnClose
         cancelText={l('cancelBtn')}

--- a/src/components/designer/lightning/actions/PayInvoiceModal.tsx
+++ b/src/components/designer/lightning/actions/PayInvoiceModal.tsx
@@ -44,7 +44,7 @@ const PayInvoiceModal: React.FC<Props> = ({ network }) => {
   return (
     <Modal
       title={l('title')}
-      visible={visible}
+      open={visible}
       onCancel={() => hidePayInvoice()}
       destroyOnClose
       cancelText={l('cancelBtn')}

--- a/src/components/home/DetectDockerModal.tsx
+++ b/src/components/home/DetectDockerModal.tsx
@@ -66,7 +66,7 @@ const DetectDockerModal: React.FC = () => {
 
   return (
     <Modal
-      visible={visible}
+      open={visible}
       closable={false}
       width={600}
       centered

--- a/src/components/nodeImages/CustomImageModal.tsx
+++ b/src/components/nodeImages/CustomImageModal.tsx
@@ -59,7 +59,7 @@ const CustomImageModal: React.FC<Props> = ({ image, onClose }) => {
   return (
     <Modal
       title={l('title', image)}
-      visible
+      open
       width={600}
       destroyOnClose
       maskClosable={false}

--- a/src/components/nodeImages/ManagedImageModal.tsx
+++ b/src/components/nodeImages/ManagedImageModal.tsx
@@ -44,7 +44,7 @@ const ManagedImageModal: React.FC<Props> = ({ image, onClose }) => {
   return (
     <Modal
       title={l('title', image)}
-      visible
+      open
       width={600}
       destroyOnClose
       onCancel={onClose}


### PR DESCRIPTION
### Description

This PR fixes a warning from the antd Modal component.
```
Warning: [antd: Modal] `visible` will be removed in next major version, please use `open` instead. 
```

It also fixes a small UI issue where the the spacing between the node name and status icon is incorrect. 

### Screenshots

![image](https://user-images.githubusercontent.com/1356600/198850064-1a3900a2-b841-42e5-b02b-200622b6264a.png)

![image](https://user-images.githubusercontent.com/1356600/198850068-d66e6009-af8c-418c-b00f-04f736bc7577.png)
