### PR TITLE
feat(bitcoind): Add Compact Filters support

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -188,6 +188,8 @@ export const dockerConfigs: Record<NodeImplementation, DockerConfig> = {
       '-listen=1',
       '-listenonion=0',
       '-fallbackfee=0.0002',
+      '-blockfilterindex=1',
+      '-peerblockfilters=1',
     ].join('\n  '),
     // if vars are modified, also update composeFile.ts & the i18n strings for cmps.nodes.CommandVariables
     variables: ['rpcUser', 'rpcAuth'],


### PR DESCRIPTION
Closes #629

### Description

This pull request add compact block filter flags to bitcoind, which are used to serve light clients.
This can be helpful when testing and experimenting with mobile wallets that supports Neutrino like https://github.com/hsjoberg/blixt-wallet.

### Steps to Test

1. Create a bitcoind backend
2. Try to sync with a compatible Neutrino client