### PR TITLE
fix(bad buffer): mint asset metadata

### DIFF
--- a/src/store/models/taro.ts
+++ b/src/store/models/taro.ts
@@ -136,11 +136,12 @@ const taroModel: TaroModel = {
 
       //mint taro asset
       const taroapi = injections.taroFactory.getService(node);
+
       const req: TARO.MintAssetRequest = {
         assetType,
         name,
         amount: assetType === PTARO.TARO_ASSET_TYPE.COLLECTIBLE ? 1 : amount,
-        metaData: Buffer.from(metaData, 'hex'),
+        metaData: Buffer.from(metaData).toString('base64'),
         enableEmission,
         skipBatch,
       };


### PR DESCRIPTION
Metadata needed to be a base64 string.
Should I write some tests for the asset info drawer? 

Closes #(issue number goes here)

### Description

Meta Data was being encoded wrong. This is fixed.

### Steps to Test

1. Mint an asset
2. Add anything meta data field
3. Open AssetInfoDrawer. You should see meta data at top
### Screenshots

[Only if applicable]
