### PR TITLE
fix(docker): properly detect docker socket path

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,14 @@ Supported Network Node Versions:
 Polar requires that you have Docker installed to create the local networks
 
 - On Mac & Windows, you can just install [Docker Desktop](https://www.docker.com/products/docker-desktop)
-- On Linux, you need to install [Docker Server](https://docs.docker.com/install/#server) and [Docker Compose](https://docs.docker.com/compose/install/) separately
+- On Linux, you need to install [Docker Server](https://docs.docker.com/engine/install/#server) and [Docker Compose](https://docs.docker.com/compose/install/#scenario-two-install-the-compose-plugin) separately.
 
 You will be prompted to install Docker if Polar cannot detect it automatically
+
+⚠️ **Important Docker Notes**
+
+- On Mac & Windows, you must uncheck "Use Docker Compose V2" in Docker Desktop settings. We're waiting on Compose v2 support in the `docker-compose` NPM package (See [PDMLab/docker-compose#228](https://github.com/PDMLab/docker-compose/pull/228))
+- On Linux, Docker Desktop is currently not supported due to a significant change in how it handles file sharing between host and container (See [#636](https://github.com/jamaljsr/polar/issues/636#issuecomment-1450201391))
 
 ## Download
 
@@ -104,7 +109,3 @@ If you would like to learn how to package Polar from source code or want to fix 
 ## Recognition
 
 Huge thanks to maintainers of [Lightning Joule](https://github.com/joule-labs/joule-extension), [Zap Wallet](https://github.com/LN-Zap/zap-desktop), [LND](https://github.com/lightningnetwork/lnd), [Bitcoin Core](https://github.com/bitcoin/bitcoin), along with many others for the amazing apps & libraries that gave this project inspiration, ideas & sometimes even a little code 😊.
-
-## Contact
-
-The best place to reach me is on Twitter @jamaljsr. I also lurk in the LND Slack server, so you can msg me there as well.

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "i18next": "22.4.13",
     "i18next-browser-languagedetector": "7.0.1",
     "i18next-scanner": "4.2.0",
+    "jest-canvas-mock": "2.5.0",
     "jest-environment-jsdom-sixteen": "1.0.3",
     "js-yaml": "4.1.0",
     "less": "4.1.3",

--- a/src/components/dockerLogs/DockerLogs.tsx
+++ b/src/components/dockerLogs/DockerLogs.tsx
@@ -6,13 +6,12 @@ import { useParams } from 'react-router';
 import { debug, error, info } from 'electron-log';
 import styled from '@emotion/styled';
 import detectPort from 'detect-port';
-import Docker from 'dockerode';
 import { usePrefixedTranslation } from 'hooks';
 import { PassThrough } from 'stream';
 import WebSocket from 'ws';
+import { getDocker } from 'lib/docker/dockerService';
 import { useStoreActions } from 'store';
 
-const docker = new Docker();
 let wsServer: WebSocket.Server;
 
 /**
@@ -27,6 +26,7 @@ const startWebSocketServer = async (name: string): Promise<number> => {
   const port = await detectPort(0);
   wsServer = new WebSocket.Server({ port });
   wsServer.on('connection', async socket => {
+    const docker = await getDocker();
     debug(`getting docker container with name '${name}'`);
     const containers = await docker.listContainers();
     debug(`all containers: ${JSON.stringify(containers)}`);

--- a/src/components/terminal/DockerTerminal.tsx
+++ b/src/components/terminal/DockerTerminal.tsx
@@ -2,20 +2,18 @@
 /* istanbul ignore file */
 import React, { useEffect, useRef } from 'react';
 import { useParams } from 'react-router';
-import { remote, clipboard } from 'electron';
+import { clipboard, remote } from 'electron';
 import { debug, info } from 'electron-log';
 import styled from '@emotion/styled';
 import 'xterm/css/xterm.css';
-import Docker from 'dockerode';
+import { message } from 'antd';
 import { usePrefixedTranslation } from 'hooks';
 import { ITerminalOptions, Terminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
+import { getDocker } from 'lib/docker/dockerService';
 import { useStoreActions } from 'store';
 import { eclairCredentials } from 'utils/constants';
 import { nord } from './themes';
-import { message } from 'antd';
-
-const docker = new Docker();
 
 // exec command and options configuration
 const execCommand = {
@@ -84,6 +82,7 @@ const connectStreams = async (term: Terminal, name: string, type: string, l: any
   const config = nodeConfig[type];
   if (!config) throw new Error(l('nodeTypeErr', { type }));
 
+  const docker = await getDocker();
   debug(`getting docker container with name '${name}'`);
   const containers = await docker.listContainers();
   debug(`all containers: ${JSON.stringify(containers)}`);

--- a/src/lib/docker/dockerService.ts
+++ b/src/lib/docker/dockerService.ts
@@ -20,8 +20,47 @@ import { legacyDataPath, networksPath, nodePath } from 'utils/config';
 import { APP_VERSION, dockerConfigs } from 'utils/constants';
 import { exists, read, write } from 'utils/files';
 import { migrateNetworksFile } from 'utils/migrations';
-import { isLinux } from 'utils/system';
+import { isLinux, isMac } from 'utils/system';
 import ComposeFile from './composeFile';
+
+let dockerInst: Dockerode | undefined;
+/**
+ * Creates a new Dockerode instance by detecting the docker socket
+ */
+export const getDocker = async (useCached = true): Promise<Dockerode> => {
+  // re-use the stored instance if available
+  if (useCached && dockerInst) return dockerInst;
+
+  if (remote.process.env.DOCKER_HOST) {
+    debug('DOCKER_HOST detected. Copying DOCKER_* env vars:');
+    // copy all env vars that start with DOCKER_ to the current process env
+    Object.keys(remote.process.env)
+      .filter(key => key.startsWith('DOCKER_'))
+      .forEach(key => {
+        debug(`- ${key} = '${remote.process.env[key]}'`);
+        process.env[key] = remote.process.env[key];
+      });
+    // let Dockerode handle DOCKER_HOST parsing
+    return (dockerInst = new Dockerode());
+  }
+  if (isLinux() || isMac()) {
+    // try to detect the socket path in the default locations on linux/mac
+    const socketPaths = [
+      `${remote.process.env.HOME}/.docker/run/docker.sock`,
+      '/var/run/docker.sock',
+    ];
+    for (const socketPath of socketPaths) {
+      if (await exists(socketPath)) {
+        debug('docker socket detected:', socketPath);
+        return (dockerInst = new Dockerode({ socketPath }));
+      }
+    }
+  }
+
+  debug('no DOCKER_HOST or docker socket detected');
+  // fallback to letting Dockerode detect the socket path
+  return (dockerInst = new Dockerode());
+};
 
 class DockerService implements DockerLibrary {
   /**
@@ -33,7 +72,7 @@ class DockerService implements DockerLibrary {
 
     try {
       debug('fetching docker version');
-      const dockerVersion = await new Dockerode().version();
+      const dockerVersion = await (await getDocker()).version();
       debug(`Result: ${JSON.stringify(dockerVersion)}`);
       versions.docker = dockerVersion.Version;
     } catch (error: any) {
@@ -60,7 +99,7 @@ class DockerService implements DockerLibrary {
   async getImages(): Promise<string[]> {
     try {
       debug('fetching docker images');
-      const allImages = await new Dockerode().listImages();
+      const allImages = await (await getDocker()).listImages();
       debug(`All Images: ${JSON.stringify(allImages)}`);
       const imageNames = ([] as string[])
         .concat(...allImages.map(i => i.RepoTags || []))

--- a/src/lib/lightning/clightning/clightningService.spec.ts
+++ b/src/lib/lightning/clightning/clightningService.spec.ts
@@ -72,6 +72,32 @@ describe('CLightningService', () => {
     expect(actual).toEqual(expected);
   });
 
+  it('should get list of channels with a funding txid', async () => {
+    const infoResponse: Partial<CLN.GetInfoResponse> = {
+      id: 'abc',
+      binding: [],
+    };
+    const chanResponse: Partial<CLN.GetChannelsResponse>[] = [
+      {
+        id: 'xyz',
+        channelId: '',
+        fundingTxid: 'bec9d46e09f7787f16e4c190b3469dab2faa41899427402d0cb558c66e2757fa',
+        state: CLN.ChannelState.CHANNELD_NORMAL,
+        msatoshiTotal: 0,
+        msatoshiToUs: 0,
+        fundingAllocationMsat: {
+          abc: 100,
+          xyz: 0,
+        },
+      },
+    ];
+    clightningApiMock.httpGet.mockResolvedValue(chanResponse);
+    clightningApiMock.httpGet.mockResolvedValueOnce(infoResponse);
+    const expected = [expect.objectContaining({ pubkey: 'xyz' })];
+    const actual = await clightningService.getChannels(node);
+    expect(actual).toEqual(expected);
+  });
+
   it('should not throw error when connecting to peers', async () => {
     const listPeersResponse: Partial<CLN.Peer>[] = [
       { id: 'asdf', connected: true, netaddr: ['1.1.1.1:9735'] },

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -5,6 +5,8 @@ import './i18n';
 import '@testing-library/jest-dom/extend-expect';
 // this is needed for antd v4 components
 import 'regenerator-runtime/runtime';
+// this is needed for antd v4 components
+import 'jest-canvas-mock';
 
 // Prevent displaying some un-fixable warnings in tests
 const originalConsoleWarning = console.warn;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6510,7 +6510,7 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-color-name@^1.0.0, color-name@~1.1.4:
+color-name@^1.0.0, color-name@^1.1.4, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
@@ -7442,6 +7442,11 @@ cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
+
+cssfontparser@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/cssfontparser/-/cssfontparser-1.2.1.tgz#f4022fc8f9700c68029d542084afbaf425a3f3e3"
+  integrity sha512-6tun4LoZnj7VN6YeegOVb67KBX/7JJsqvj+pv3ZA7F878/eN33AbGa5b/S/wXxS/tcp8nc40xRUrsPlxIyNUPg==
 
 cssnano-preset-default@^4.0.7:
   version "4.0.7"
@@ -12262,6 +12267,14 @@ jake@^10.8.5:
     filelist "^1.0.1"
     minimatch "^3.0.4"
 
+jest-canvas-mock@2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/jest-canvas-mock/-/jest-canvas-mock-2.5.0.tgz#3e60f87f77ddfa273cf8e7e4ea5f86fa827c7117"
+  integrity sha512-s2bmY2f22WPMzhB2YA93kiyf7CAfWAnV/sFfY9s48IVOrGmwui1eSFluDPesq1M+7tSC1hJAit6mzO0ZNXvVBA==
+  dependencies:
+    cssfontparser "^1.2.1"
+    moo-color "^1.0.2"
+
 jest-changed-files@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-26.6.2.tgz#f6198479e1cc66f22f9ae1e22acaa0b429c042d0"
@@ -14291,6 +14304,13 @@ monocle-ts@^2.3.5:
   version "2.3.11"
   resolved "https://registry.yarnpkg.com/monocle-ts/-/monocle-ts-2.3.11.tgz#562cd960bc24eaa84d9b6118d46a5441f3c0aac0"
   integrity sha512-YJQdpDeKU0NNAecDjFgDDnDoivmf2nXsJZTRQdKh5jsPKG2lT/15dFnSuUcQoKB/VZN1z7jQ0B0bffbRFUtLmg==
+
+moo-color@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/moo-color/-/moo-color-1.0.3.tgz#d56435f8359c8284d83ac58016df7427febece74"
+  integrity sha512-i/+ZKXMDf6aqYtBhuOcej71YSlbjT3wCO/4H1j8rPvxDJEifdwgg5MaFyu6iYAT8GBZJg2z0dkgK4YMzvURALQ==
+  dependencies:
+    color-name "^1.1.4"
 
 move-concurrently@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
### Description

Docker Desktop for Mac no longer places the UNIX socket in the location `/var/run/docker.sock` for new installations. This prevents Polar from detecting the current version of Docker on the machine. This PR adds detection for the socket file in the new location `~/.docker/run/docker.sock`.

I also updated the README with notes on the currently outstanding issues with Docker. 

> ⚠️ **Important Docker Notes**
> 
> - On Mac & Windows, you must uncheck "Use Docker Compose V2" in Docker Desktop settings. We're waiting on Compose v2 support in the `docker-compose` NPM package (See [PDMLab/docker-compose#228](https://github.com/PDMLab/docker-compose/pull/228))
> - On Linux, Docker Desktop is currently not supported due to a significant change in how it handles file sharing between host and container (See [#636](https://github.com/jamaljsr/polar/issues/636#issuecomment-1450201391))
