### PR TITLE
fix(network): clear RPC cache when nodes are stopped

### DIFF
--- a/src/store/models/network.ts
+++ b/src/store/models/network.ts
@@ -537,13 +537,15 @@ const networkModel: NetworkModel = {
       }
     },
   ),
-  stop: thunk(async (actions, networkId, { getState, injections }) => {
+  stop: thunk(async (actions, networkId, { getState, injections, getStoreActions }) => {
     const network = getState().networks.find(n => n.id === networkId);
     if (!network) throw new Error(l('networkByIdErr', { networkId }));
     actions.setStatus({ id: network.id, status: Status.Stopping });
     try {
       await injections.dockerService.stop(network);
       actions.setStatus({ id: network.id, status: Status.Stopped });
+      // clear cached RPC data
+      getStoreActions().app.clearAppCache();
     } catch (e: any) {
       actions.setStatus({ id: network.id, status: Status.Error });
       info(`unable to stop network '${network.name}'`, e.message);
@@ -560,7 +562,7 @@ const networkModel: NetworkModel = {
     }
     await actions.save();
   }),
-  toggleNode: thunk(async (actions, node, { getState, injections }) => {
+  toggleNode: thunk(async (actions, node, { getState, injections, getStoreActions }) => {
     const { networkId } = node;
     let network = getState().networks.find(n => n.id === networkId);
     if (!network) throw new Error(l('networkByIdErr', { networkId }));
@@ -579,12 +581,14 @@ const networkModel: NetworkModel = {
         await injections.dockerService.saveComposeFile(network);
       }
       await injections.dockerService.startNode(network, node);
-      await actions.monitorStartup([node]);
+      actions.monitorStartup([node]);
     } else if (node.status === Status.Started) {
       // stop the node container
       actions.setStatus({ id: network.id, status: Status.Stopping, only });
       await injections.dockerService.stopNode(network, node);
       actions.setStatus({ id: network.id, status: Status.Stopped, only });
+      // clear cached RPC data
+      getStoreActions().app.clearAppCache();
     }
     await actions.save();
   }),


### PR DESCRIPTION
Closes #508 

### Description

Currently, Polar caches the LND certificate & macaroon in memory to avoid going to disk for every RPC request. The side effect of this is that if the files are regenerated by deleting them then restarting LND, Polar continues to use the cached values. Because of this, Polar can no longer communicate with the node that now requires the updated values. 

This PR fixes this issue by clearing the cache when a node is stopped. When the node is started again, the cache will be empty and Polar will read the files from disk. The values will be cached in memory again until the node is stopped.

### Steps to Test

1. Create new network with 1 bitcoind and 1 lnd node
1. Start the network
1. Make note of the TLS cert hex value
1. Open terminal for lnd node (alice)
1. `rm /home/lnd/.lnd/tls.*`
1. Restart `lnd` node (alice)
1. Confirm that the node starts successfully, indicating that Polar is now using the new cert
1. Confirm the TLS cert hex value is different than the one noted in step 3
