### PR TITLE
docker: support docker-compose v2 + minor improvements

### DIFF
--- a/src/__mocks__/docker-compose.js
+++ b/src/__mocks__/docker-compose.js
@@ -6,4 +6,13 @@ module.exports = {
   down: jest.fn(),
   rm: jest.fn(),
   version: jest.fn(),
+  v2: {
+    upAll: jest.fn(),
+    upOne: jest.fn(),
+    stop: jest.fn(),
+    stopOne: jest.fn(),
+    down: jest.fn(),
+    rm: jest.fn(),
+    version: jest.fn(),
+  },
 };

--- a/src/lib/docker/composeFile.spec.ts
+++ b/src/lib/docker/composeFile.spec.ts
@@ -4,7 +4,7 @@ import { getNetwork } from 'utils/tests';
 import ComposeFile from './composeFile';
 
 describe('ComposeFile', () => {
-  let composeFile = new ComposeFile();
+  let composeFile = new ComposeFile(1);
   const network = getNetwork();
   const btcNode = network.nodes.bitcoin[0];
   const lndNode = network.nodes.lightning[0] as LndNode;
@@ -16,7 +16,7 @@ describe('ComposeFile', () => {
   const tapLndNode = network.nodes.lightning[0] as LndNode;
 
   beforeEach(() => {
-    composeFile = new ComposeFile();
+    composeFile = new ComposeFile(1);
   });
 
   it('should have no services initially', () => {
@@ -25,6 +25,10 @@ describe('ComposeFile', () => {
 
   it('should have a valid docker version', () => {
     expect(composeFile.content.version).toEqual('3.3');
+  });
+
+  it('should have a a name', () => {
+    expect(composeFile.content.name).toEqual('polar-network-1');
   });
 
   it('should add multiple services', () => {

--- a/src/lib/docker/composeFile.ts
+++ b/src/lib/docker/composeFile.ts
@@ -25,6 +25,7 @@ export interface ComposeService {
 
 export interface ComposeContent {
   version: string;
+  name: string;
   services: {
     [key: string]: ComposeService;
   };
@@ -33,9 +34,10 @@ export interface ComposeContent {
 class ComposeFile {
   content: ComposeContent;
 
-  constructor() {
+  constructor(id: number) {
     this.content = {
       version: '3.3',
+      name: `polar-network-${id}`,
       services: {},
     };
   }

--- a/src/lib/docker/dockerService.spec.ts
+++ b/src/lib/docker/dockerService.spec.ts
@@ -2,7 +2,7 @@ import * as electron from 'electron';
 import * as fs from 'fs-extra';
 import { join } from 'path';
 import { IChart } from '@mrblenny/react-flow-chart';
-import * as compose from 'docker-compose';
+import { v2 as compose } from 'docker-compose';
 import Dockerode from 'dockerode';
 import os from 'os';
 import { CLightningNode, LndNode, TapdNode } from 'shared/types';

--- a/src/lib/docker/dockerService.ts
+++ b/src/lib/docker/dockerService.ts
@@ -122,7 +122,7 @@ class DockerService implements DockerLibrary {
    * @param network the network to save a compose file for
    */
   async saveComposeFile(network: Network) {
-    const file = new ComposeFile();
+    const file = new ComposeFile(network.id);
     const { bitcoin, lightning, tap } = network.nodes;
 
     bitcoin.forEach(node => file.addBitcoind(node));

--- a/src/lib/docker/dockerService.ts
+++ b/src/lib/docker/dockerService.ts
@@ -2,7 +2,7 @@ import { remote } from 'electron';
 import { debug, info } from 'electron-log';
 import { copy, ensureDir } from 'fs-extra';
 import { join } from 'path';
-import * as compose from 'docker-compose';
+import { v2 as compose } from 'docker-compose';
 import Dockerode from 'dockerode';
 import yaml from 'js-yaml';
 import os from 'os';
@@ -66,7 +66,7 @@ export const getDocker = async (useCached = true): Promise<Dockerode> => {
 
 class DockerService implements DockerLibrary {
   /**
-   * Gets the versions of docker and docker-compose installed
+   * Gets the versions of docker and docker compose installed
    * @param throwOnError set to true to throw an Error if detection fails
    */
   async getVersions(throwOnError?: boolean): Promise<DockerVersions> {
@@ -83,7 +83,7 @@ class DockerService implements DockerLibrary {
     }
 
     try {
-      debug('getting docker-compose version');
+      debug('getting docker compose version');
       const composeVersion = await this.execute(compose.version, this.getArgs());
       debug(`Result: ${JSON.stringify(composeVersion)}`);
       versions.compose = composeVersion.out.trim();
@@ -160,7 +160,7 @@ class DockerService implements DockerLibrary {
   }
 
   /**
-   * Start a network using docker-compose
+   * Start a network using docker compose
    * @param network the network to start
    */
   async start(network: Network) {
@@ -174,7 +174,7 @@ class DockerService implements DockerLibrary {
   }
 
   /**
-   * Stop a network using docker-compose
+   * Stop a network using docker compose
    * @param network the network to stop
    */
   async stop(network: Network) {
@@ -185,7 +185,7 @@ class DockerService implements DockerLibrary {
   }
 
   /**
-   * Starts a single service using docker-compose
+   * Starts a single service using docker compose
    * @param network the network containing the node
    * @param node the node to start
    */
@@ -202,7 +202,7 @@ class DockerService implements DockerLibrary {
   }
 
   /**
-   * Stops a single service using docker-compose
+   * Stops a single service using docker compose
    * @param network the network containing the node
    * @param node the node to stop
    */
@@ -214,7 +214,7 @@ class DockerService implements DockerLibrary {
   }
 
   /**
-   * Removes a single service from the network using docker-compose
+   * Removes a single service from the network using docker compose
    * @param network the network containing the node
    * @param node the node to remove
    */

--- a/src/lib/docker/nodeTemplates.ts
+++ b/src/lib/docker/nodeTemplates.ts
@@ -17,11 +17,8 @@ export const bitcoind = (
 ): ComposeService => ({
   image,
   container_name: container,
-  environment: {
-    USERID: '${USERID:-1000}',
-    GROUPID: '${GROUPID:-1000}',
-  },
   hostname: name,
+  stop_grace_period: '5m',
   command: trimInside(command),
   volumes: [
     `./volumes/${dockerConfigs.bitcoind.volumeDirName}/${name}:/home/bitcoin/.bitcoin`,
@@ -51,10 +48,6 @@ export const lnd = (
 ): ComposeService => ({
   image,
   container_name: container,
-  environment: {
-    USERID: '${USERID:-1000}',
-    GROUPID: '${GROUPID:-1000}',
-  },
   hostname: name,
   command: trimInside(command),
   restart: 'always',
@@ -82,10 +75,6 @@ export const clightning = (
 ): ComposeService => ({
   image,
   container_name: container,
-  environment: {
-    USERID: '${USERID:-1000}',
-    GROUPID: '${GROUPID:-1000}',
-  },
   hostname: name,
   command: trimInside(command),
   restart: 'always',
@@ -115,10 +104,6 @@ export const eclair = (
 ): ComposeService => ({
   image,
   container_name: container,
-  environment: {
-    USERID: '${USERID:-1000}',
-    GROUPID: '${GROUPID:-1000}',
-  },
   hostname: name,
   command: trimInside(command),
   restart: 'always',
@@ -146,10 +131,6 @@ export const tapd = (
 ): ComposeService => ({
   image,
   container_name: container,
-  environment: {
-    USERID: '${USERID:-1000}',
-    GROUPID: '${GROUPID:-1000}',
-  },
   hostname: name,
   command: trimInside(command),
   restart: 'always',


### PR DESCRIPTION
Closes #719 
Closes #614 

### Description

This PR adds support for Docker Compose v2 since v1 has officially been deprecated.

I also updated the compose file to give nodes more time to gracefully shutdown and added a `name` field to avoid the dirname of `1` being displayed in Docker Desktop.