### PR TITLE
fix(docker): properly handle new node types in updates

### DIFF
--- a/src/lib/docker/repoService.spec.ts
+++ b/src/lib/docker/repoService.spec.ts
@@ -77,5 +77,39 @@ describe('RepoService', () => {
       expect(result.updates).toBeDefined();
       expect(result.updates?.bitcoind).toEqual(['1.0.0']);
     });
+
+    it('should ignore a new implementation in the remote state', async () => {
+      const newImplState: any = {
+        ...defaultRepoState,
+        version: defaultRepoState.version + 1,
+        images: {
+          ...defaultRepoState.images,
+          newImpl: {
+            latest: '1.0.0',
+            versions: ['1.0.0'],
+          },
+        },
+      };
+
+      utilsMock.httpRequest.mockResolvedValue(JSON.stringify(clone(newImplState)));
+      const result: any = await repoService.checkForUpdates(localState);
+      expect(result.state).toEqual(localState);
+      expect(result.updates).not.toBeDefined();
+      expect(result.updates?.newImpl).not.toBeDefined();
+    });
+
+    it('should handle a removed implementation in the remote state', async () => {
+      const remoteState = {
+        ...clone(localState),
+        version: localState.version + 1,
+        images: {
+          ...localState.images,
+          eclair: undefined,
+        },
+      };
+      utilsMock.httpRequest.mockResolvedValue(JSON.stringify(remoteState));
+      const result: any = await repoService.checkForUpdates(localState);
+      expect(result.state).toEqual(localState);
+    });
   });
 });

--- a/src/lib/docker/repoService.ts
+++ b/src/lib/docker/repoService.ts
@@ -67,6 +67,8 @@ class RepoService implements RepoServiceInjection {
     let newVersionCount = 0;
     Object.entries(remoteState.images).forEach(([name, remoteImage]) => {
       const impl = name as NodeImplementation;
+      // skip if the local state doesn't have this implementation
+      if (!localState.images[impl]) return;
       const localVersions = localState.images[impl].versions;
       const newVersions = remoteImage.versions.filter(v => !localVersions.includes(v));
       if (newVersions.length) {


### PR DESCRIPTION
Closes #723

Fixes an issue with updating node versions after a new implementation (ex: tapd) is added.
