### PR TITLE
Add --tlsextradomain=host.docker.internal to lnd default args

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -98,6 +98,7 @@ export const dockerConfigs: Record<NodeImplementation, DockerConfig> = {
       '--externalip={{name}}',
       '--tlsextradomain={{name}}',
       '--tlsextradomain={{containerName}}',
+      '--tlsextradomain=host.docker.internal',
       '--listen=0.0.0.0:9735',
       '--rpclisten=0.0.0.0:10009',
       '--restlisten=0.0.0.0:8080',


### PR DESCRIPTION
Hi Hi!

I am working on a one-click docker-compose setup for Blocktank, our open-source Synonym LSP solution. The goal is to make it work seamlessly with Polar so one can test and develop Blocktank without any issues.
To make it as seamless as possible, an additional LND default argument is required.

### Description

This PR adds `--tlsextradomain=host.docker.internal` to the LND default arguments. [host.docker.internal](https://docs.docker.com/desktop/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host) is a special domain name in docker that resolves to the IP address of the host system. This allows other docker containers (not in the same docker network) to connect to the LND GRPC port exposed to the host machine.

Without this argument, LND TLS will reject the GRPC connection due to the unknown domain name.

At the moment, Blocktank users need to
1. Add this extra argument in "Advanced Options".
2. Open Terminal and delete the existing TLS certificate.
3. Restart the container to regenerate the cert.

I tried to programatically add this argument to the networks.json but Polar doesn't like changes in networks.json while it's running.

Adding this as default argument, solves this cumbersome problem. I am sure other apps using Polar will appreciate this change as well.

Thanks for having a look. Let me know if you need something else changed in this PR.


