### PR TITLE
fix(cln): use node hostname for P2P Internal url

### DIFF
--- a/src/lib/lightning/clightning/clightningService.spec.ts
+++ b/src/lib/lightning/clightning/clightningService.spec.ts
@@ -14,7 +14,7 @@ describe('CLightningService', () => {
     const infoResponse: Partial<CLN.GetInfoResponse> = {
       id: 'asdf',
       alias: '',
-      binding: [{ type: 'ipv4', address: '1.1.1.1', port: 9735 }],
+      binding: [{ type: 'ipv4', address: '0.0.0.0', port: 9735 }],
       blockheight: 0,
       numActiveChannels: 0,
       numPendingChannels: 0,
@@ -22,7 +22,7 @@ describe('CLightningService', () => {
       warningLightningdSync: 'blah',
     };
     clightningApiMock.httpGet.mockResolvedValue(infoResponse);
-    const expected = defaultStateInfo({ pubkey: 'asdf', rpcUrl: 'asdf@1.1.1.1:9735' });
+    const expected = defaultStateInfo({ pubkey: 'asdf', rpcUrl: 'asdf@bob:9735' });
     const actual = await clightningService.getInfo(node);
     expect(actual).toEqual(expected);
   });

--- a/src/lib/lightning/clightning/clightningService.ts
+++ b/src/lib/lightning/clightning/clightningService.ts
@@ -27,7 +27,7 @@ class CLightningService implements LightningService {
       alias: info.alias,
       rpcUrl: info.binding
         .filter(b => b.type === 'ipv4')
-        .reduce((v, b) => `${info.id}@${b.address}:${b.port}`, ''),
+        .reduce((v, b) => `${info.id}@${node.name}:${b.port}`, ''),
       syncedToChain: !info.warningBitcoindSync && !info.warningLightningdSync,
       blockHeight: info.blockheight,
       numActiveChannels: info.numActiveChannels,


### PR DESCRIPTION
Closes #747 
Closes #758 

### Description

Fixes a bug where Core Lightning nodes are unable to peer with other nodes and therefore not able to open outbound channels.

### Steps to Test

1. Create a new network with two Core Lightning nodes
2. Start the network
3. Select a Core Lightning node
4. Click the Connect tab
5. Confirm the "P2P Internal" url contains the name of the node (ex: 02f...19f2132f@bob:9735) instead of `0.0.0.0`

### Screenshots

![image](https://github.com/jamaljsr/polar/assets/1356600/6e71414f-9590-4516-a5b0-62dd6ae9721a)
