### PR TITLE
feat(cln): save Core Lightning logs to disk

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -133,6 +133,8 @@ export const dockerConfigs: Record<NodeImplementation, DockerConfig> = {
       '--dev-bitcoind-poll=2',
       '--dev-fast-gossip',
       '--grpc-port=11001',
+      '--log-file=-', // log to stdout
+      '--log-file=/home/clightning/.lightning/debug.log',
       '--plugin=/opt/c-lightning-rest/plugin.js',
       '--rest-port=8080',
       '--rest-protocol=http',


### PR DESCRIPTION
Closes #755

### Description

Adds the `--log-file` flag to Core Lightning nodes in order to log to disk in addition to stdout.

### Steps to Test

1. Create and start a new network with a Core Lightning Node
2. Right-click on the node and select "View Logs" to see the logs
3. Confirm the log file exists on your machine at `~/.polar/networks/1/volumes/c-lightning/bob/lightningd/debug.log`

