### PR TITLE
fix download broken links + update download links to v2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ You will be prompted to install Docker if Polar cannot detect it automatically
 
 ## Download
 
-Download Polar v2.0.0 for your OS
+Download Polar v2.1.0 for your OS
 
-- Mac ([dmg](https://github.com/jamaljsr/polar/releases/download/v2.0.0/polar-mac-v2.0.0.dmg))
-- Linux ([deb](https://github.com/jamaljsr/polar/releases/download/v2.0.0/polar-linux-amd64-v2.0.0.deb), [AppImage](https://github.com/jamaljsr/polar/releases/download/v2.0.0/polar-linux-x86_64-v2.0.0.AppImage))
-- Windows ([exe](https://github.com/jamaljsr/polar/releases/download/v2.0.0/polar-win-v2.0.0.exe))
+- Mac ([dmg](https://github.com/jamaljsr/polar/releases/download/v2.1.0/polar-mac-x64-v2.1.0.dmg))
+- Linux ([deb](https://github.com/jamaljsr/polar/releases/download/v2.1.0/polar-linux-amd64-v2.1.0.deb), [AppImage](https://github.com/jamaljsr/polar/releases/download/v2.1.0/polar-linux-x86_64-v2.1.0.AppImage))
+- Windows ([exe](https://github.com/jamaljsr/polar/releases/download/v2.1.0/polar-win-x64-v2.1.0.exe))
 
 Alternative and older version binaries can be found in the [GitHub releases](https://github.com/jamaljsr/polar/releases)
 


### PR DESCRIPTION
fixing broken download links for Mac and Windows.

also noticed that a new version was released yesterday, so updated the links to point to `v2.1.0`. 
pls let me know if keeping `v2.0.0` is intended and I'll update the PR.