### PR TITLE
feat(images): add support for tapd v0.3.3-alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Supported Network Node Versions:
 - [Core Lightning](https://github.com/ElementsProject/lightning) - v23.05.2, v23.02.2, v22.11, v0.12.0, v0.11.2, v0.10.2
 - [Eclair](https://github.com/ACINQ/eclair/) - v0.10.0, v0.9.0, v0.8.0, v0.7.0, v0.6.2, v0.5.0
 - [Bitcoin Core](https://github.com/bitcoin/bitcoin) - v26.0, v25.0, v24.0, v23.0, v22.0, v0.21.1
-- [Taproot Assets](https://github.com/lightninglabs/taproot-assets) - v0.3.1
+- [Taproot Assets](https://github.com/lightninglabs/taproot-assets) - v0.3.2
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Supported Network Node Versions:
 - [Core Lightning](https://github.com/ElementsProject/lightning) - v23.05.2, v23.02.2, v22.11, v0.12.0, v0.11.2, v0.10.2
 - [Eclair](https://github.com/ACINQ/eclair/) - v0.10.0, v0.9.0, v0.8.0, v0.7.0, v0.6.2, v0.5.0
 - [Bitcoin Core](https://github.com/bitcoin/bitcoin) - v26.0, v25.0, v24.0, v23.0, v22.0, v0.21.1
-- [Taproot Assets](https://github.com/lightninglabs/taproot-assets) - v0.3.2
+- [Taproot Assets](https://github.com/lightninglabs/taproot-assets) - v0.3.3, v0.3.2
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Supported Network Node Versions:
 - [Core Lightning](https://github.com/ElementsProject/lightning) - v23.05.2, v23.02.2, v22.11, v0.12.0, v0.11.2, v0.10.2
 - [Eclair](https://github.com/ACINQ/eclair/) - v0.10.0, v0.9.0, v0.8.0, v0.7.0, v0.6.2, v0.5.0
 - [Bitcoin Core](https://github.com/bitcoin/bitcoin) - v26.0, v25.0, v24.0, v23.0, v22.0, v0.21.1
-- [Taproot Assets](https://github.com/lightninglabs/taproot-assets) - v0.3.0
+- [Taproot Assets](https://github.com/lightninglabs/taproot-assets) - v0.3.1
 
 ## Dependencies
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -159,6 +159,7 @@ Replace `<version>` with the desired Eclair version (ex: `0.3.3`).
 
 ### Tags
 
+- `0.3.2-alpha` ([tap/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/tapd/Dockerfile))
 - `0.3.1-alpha` ([tap/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/tapd/Dockerfile))
 - `0.3.0-alpha` ([tap/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/tapd/Dockerfile))
 - `0.2.3-alpha` ([tap/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/tapd/Dockerfile))

--- a/docker/README.md
+++ b/docker/README.md
@@ -159,6 +159,7 @@ Replace `<version>` with the desired Eclair version (ex: `0.3.3`).
 
 ### Tags
 
+- `0.3.3-alpha` ([tap/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/tapd/Dockerfile))
 - `0.3.2-alpha` ([tap/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/tapd/Dockerfile))
 - `0.3.1-alpha` ([tap/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/tapd/Dockerfile))
 - `0.3.0-alpha` ([tap/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/tapd/Dockerfile))

--- a/docker/README.md
+++ b/docker/README.md
@@ -159,6 +159,7 @@ Replace `<version>` with the desired Eclair version (ex: `0.3.3`).
 
 ### Tags
 
+- `0.3.1-alpha` ([tap/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/tapd/Dockerfile))
 - `0.3.0-alpha` ([tap/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/tapd/Dockerfile))
 - `0.2.3-alpha` ([tap/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/tapd/Dockerfile))
 - `0.2.2-alpha` ([tap/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/tapd/Dockerfile))

--- a/docker/nodes.json
+++ b/docker/nodes.json
@@ -49,9 +49,10 @@
       "versions": []
     },
     "tapd": {
-      "latest": "0.3.2-alpha",
-      "versions": ["0.3.2-alpha"],
+      "latest": "0.3.3-alpha",
+      "versions": ["0.3.3-alpha", "0.3.2-alpha"],
       "compatibility": {
+        "0.3.3-alpha": "0.16.0-beta",
         "0.3.2-alpha": "0.16.0-beta"
       }
     }

--- a/docker/nodes.json
+++ b/docker/nodes.json
@@ -49,11 +49,10 @@
       "versions": []
     },
     "tapd": {
-      "latest": "0.3.1-alpha",
-      "versions": ["0.3.1-alpha", "0.3.0-alpha"],
+      "latest": "0.3.2-alpha",
+      "versions": ["0.3.2-alpha"],
       "compatibility": {
-        "0.3.1-alpha": "0.16.0-beta",
-        "0.3.0-alpha": "0.16.0-beta"
+        "0.3.2-alpha": "0.16.0-beta"
       }
     }
   }

--- a/docker/nodes.json
+++ b/docker/nodes.json
@@ -49,9 +49,10 @@
       "versions": []
     },
     "tapd": {
-      "latest": "0.3.0-alpha",
-      "versions": ["0.3.0-alpha"],
+      "latest": "0.3.1-alpha",
+      "versions": ["0.3.1-alpha", "0.3.0-alpha"],
       "compatibility": {
+        "0.3.1-alpha": "0.16.0-beta",
         "0.3.0-alpha": "0.16.0-beta"
       }
     }

--- a/electron/tapd/tapdProxyServer.ts
+++ b/electron/tapd/tapdProxyServer.ts
@@ -89,7 +89,7 @@ const decodeAddress = async (args: {
 
 const assetRoots = async (args: { node: TapdNode }): Promise<TARO.AssetRootResponse> => {
   const { universe } = await getRpc(args.node);
-  return await universe.assetRoots();
+  return await universe.assetRoots({ withAmountsById: true });
 };
 
 const assetLeaves = async (args: {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "tsc": "tsc --noEmit"
   },
   "dependencies": {
-    "@lightningpolar/tapd-api": "0.3.1-alpha",
+    "@lightningpolar/tapd-api": "0.3.2-alpha",
     "@radar/lnrpc": "0.11.1-beta.1",
     "@types/detect-port": "1.3.5",
     "archiver": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "tsc": "tsc --noEmit"
   },
   "dependencies": {
-    "@lightningpolar/tapd-api": "0.3.2-alpha",
+    "@lightningpolar/tapd-api": "^0.3.3-alpha",
     "@radar/lnrpc": "0.11.1-beta.1",
     "@types/detect-port": "1.3.5",
     "archiver": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "tsc": "tsc --noEmit"
   },
   "dependencies": {
-    "@lightningpolar/tapd-api": "0.3.0-alpha.rc1",
+    "@lightningpolar/tapd-api": "0.3.1-alpha",
     "@radar/lnrpc": "0.11.1-beta.1",
     "@types/detect-port": "1.3.5",
     "archiver": "7.0.0",

--- a/src/components/designer/tap/actions/MintAssetModal.spec.tsx
+++ b/src/components/designer/tap/actions/MintAssetModal.spec.tsx
@@ -109,6 +109,7 @@ describe('MintAssetModal', () => {
       );
       tapServiceMock.mintAsset.mockResolvedValue({
         pendingBatch: {
+          batchTxid: 'mocked-txid',
           batchKey: Buffer.from('mocked success!'),
           assets: [],
           state: 'BATCH_STATE_FINALIZED',

--- a/src/lib/tap/tapd/tapdService.spec.ts
+++ b/src/lib/tap/tapd/tapdService.spec.ts
@@ -27,8 +27,8 @@ const sampleAsset: Asset = {
     ),
     outputIndex: 0,
     version: 0,
+    assetType: 'NORMAL',
   },
-  assetType: 'NORMAL',
   amount: '900',
   lockTime: 0,
   relativeLockTime: 0,
@@ -42,7 +42,6 @@ const sampleAsset: Asset = {
     anchorTx: Buffer.from(
       '02000000000102217b7c61d585238f5e1a614ef5c4041c32ca9eedcae38c608b22dc5d256410110100000000ffffffff217b7c61d585238f5e1a614ef5c4041c32ca9eedcae38c608b22dc5d2564101100000000000000000003e803000000000000225120540b38f3ef8dcf37d5c85b89d5ba15274cdc13f4d7cf300cfcdeedc3b1335d6de8030000000000002251205f158a5743cd9747732cb03b0a605cb08719ff5cf58234b7ec5276c851494e6e81e80e0000000000225120c2b958e9c347a30781e358940d20adef09079ae604faa509a34d789d5697e4c40140786d837c15c27efdf459b071a8b68691080c0e6c4d152b15cd359254e1408f76f2e8ca8680b0035202bb9e5407101aca5fa45a3c556f7e28cf275f19a584dd4001407883d96a241cd6354efacea726b0abbb8ec63f8b417d1cc5bb903078761dd0da58573a11972204a056bcc5f2c489682e5122521c128d7015a8bca7b1b690691100000000',
     ),
-    anchorTxid: '3e946b82861faedf8176cf790aeeb9fe3e70247b80ed0f510c62c4055ebea8f7',
     anchorBlockHash: '6a748adfd6a1399d08978c117767b29fe83ede8fe4cb0186eba41e942dd04542',
     anchorOutpoint: 'f7a8be5e05c4620c510fed807b24703efeb9ee0a79cf7681dfae1f86826b943e:0',
     internalKey: Buffer.from(
@@ -71,8 +70,8 @@ const sampleBalance: AssetBalance = {
     ),
     outputIndex: 0,
     version: 0,
+    assetType: 'NORMAL',
   },
-  assetType: 'NORMAL',
   balance: '100',
 };
 

--- a/src/lib/tap/tapd/tapdService.ts
+++ b/src/lib/tap/tapd/tapdService.ts
@@ -76,7 +76,7 @@ class TapdService implements TapService {
       return {
         id: genesis.assetId.toString(),
         name: genesis.name,
-        type: asset.assetType,
+        type: genesis.assetType,
         amount: asset.amount,
         genesisPoint: genesis.genesisPoint,
         anchorOutpoint: anchor.anchorOutpoint,
@@ -95,7 +95,7 @@ class TapdService implements TapService {
       balances.push({
         id,
         name: genesis.name,
-        type: asset.assetType,
+        type: genesis.assetType,
         balance: asset.balance,
         genesisPoint: genesis.genesisPoint,
       });

--- a/src/shared/tapdDefaults.ts
+++ b/src/shared/tapdDefaults.ts
@@ -27,6 +27,7 @@ export const defaultTapdListBalances = (
 
 export const defaultTapdMintAsset = (): MintAssetResponse => ({
   pendingBatch: {
+    batchTxid: '',
     batchKey: Buffer.from(''),
     assets: [],
     state: 'BATCH_STATE_PEDNING',
@@ -37,6 +38,7 @@ export const defaultTapdFinalizeBatch = (
   value: Partial<FinalizeBatchResponse>,
 ): FinalizeBatchResponse => ({
   batch: {
+    batchTxid: '',
     batchKey: Buffer.from(''),
     assets: [],
     state: 'BATCH_STATE_FINALIZED',

--- a/src/shared/tapdDefaults.ts
+++ b/src/shared/tapdDefaults.ts
@@ -30,7 +30,7 @@ export const defaultTapdMintAsset = (): MintAssetResponse => ({
     batchTxid: '',
     batchKey: Buffer.from(''),
     assets: [],
-    state: 'BATCH_STATE_PEDNING',
+    state: 'BATCH_STATE_PENDING',
   },
 });
 

--- a/src/store/models/designer.spec.ts
+++ b/src/store/models/designer.spec.ts
@@ -513,7 +513,8 @@ describe('Designer model', () => {
             expect.objectContaining({
               message: 'Failed to add node',
               error: new Error(
-                'This network does not contain a LND v0.16.0-beta (or higher) node which is required for tapd v0.3.1-alpha',
+                'This network does not contain a LND v0.16.0-beta (or higher) ' +
+                  `node which is required for tapd v${tapdLatest}`,
               ),
             }),
           );

--- a/src/store/models/designer.spec.ts
+++ b/src/store/models/designer.spec.ts
@@ -513,7 +513,7 @@ describe('Designer model', () => {
             expect.objectContaining({
               message: 'Failed to add node',
               error: new Error(
-                'This network does not contain a LND v0.16.0-beta (or higher) node which is required for tapd v0.3.0-alpha',
+                'This network does not contain a LND v0.16.0-beta (or higher) node which is required for tapd v0.3.1-alpha',
               ),
             }),
           );

--- a/src/store/models/tap.ts
+++ b/src/store/models/tap.ts
@@ -160,8 +160,8 @@ const tapModel: TapModel = {
           assetType,
           name,
           amount: assetType === PTAP.TAP_ASSET_TYPE.COLLECTIBLE ? '1' : amount.toString(),
+          newGroupedAsset: enableEmission,
         },
-        enableEmission,
       };
       const res = await api.mintAsset(node, req);
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -306,9 +306,10 @@ export const defaultRepoState: DockerRepoState = {
       versions: [],
     },
     tapd: {
-      latest: '0.3.2-alpha',
-      versions: ['0.3.2-alpha'],
+      latest: '0.3.3-alpha',
+      versions: ['0.3.3-alpha', '0.3.2-alpha'],
       compatibility: {
+        '0.3.3-alpha': '0.16.0-beta',
         '0.3.2-alpha': '0.16.0-beta',
       },
     },

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -306,11 +306,10 @@ export const defaultRepoState: DockerRepoState = {
       versions: [],
     },
     tapd: {
-      latest: '0.3.1-alpha',
-      versions: ['0.3.1-alpha', '0.3.0-alpha'],
+      latest: '0.3.2-alpha',
+      versions: ['0.3.2-alpha'],
       compatibility: {
-        '0.3.1-alpha': '0.16.0-beta',
-        '0.3.0-alpha': '0.16.0-beta',
+        '0.3.2-alpha': '0.16.0-beta',
       },
     },
   },

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -306,9 +306,10 @@ export const defaultRepoState: DockerRepoState = {
       versions: [],
     },
     tapd: {
-      latest: '0.3.0-alpha',
-      versions: ['0.3.0-alpha'],
+      latest: '0.3.1-alpha',
+      versions: ['0.3.1-alpha', '0.3.0-alpha'],
       compatibility: {
+        '0.3.1-alpha': '0.16.0-beta',
         '0.3.0-alpha': '0.16.0-beta',
       },
     },

--- a/src/utils/tests/helpers.ts
+++ b/src/utils/tests/helpers.ts
@@ -156,8 +156,9 @@ export const testRepoState: DockerRepoState = {
       versions: [],
     },
     tapd: {
-      latest: '0.3.2-alpha',
+      latest: '0.3.3-alpha',
       versions: [
+        '0.3.3-alpha',
         '0.3.2-alpha',
         '0.3.1-alpha',
         '0.2.3-alpha',
@@ -165,6 +166,7 @@ export const testRepoState: DockerRepoState = {
         '0.2.0-alpha',
       ],
       compatibility: {
+        '0.3.3-alpha': '0.16.0-beta',
         '0.3.2-alpha': '0.16.0-beta',
         '0.3.1-alpha': '0.16.0-beta',
         '0.3.0-alpha': '0.16.0-beta',

--- a/src/utils/tests/helpers.ts
+++ b/src/utils/tests/helpers.ts
@@ -156,9 +156,10 @@ export const testRepoState: DockerRepoState = {
       versions: [],
     },
     tapd: {
-      latest: '0.3.0-alpha',
-      versions: ['0.3.0-alpha', '0.2.3-alpha', '0.2.2-alpha', '0.2.0-alpha'],
+      latest: '0.3.1-alpha',
+      versions: ['0.3.1-alpha', '0.2.3-alpha', '0.2.2-alpha', '0.2.0-alpha'],
       compatibility: {
+        '0.3.1-alpha': '0.16.0-beta',
         '0.3.0-alpha': '0.16.0-beta',
         '0.2.3-alpha': '0.16.0-beta',
         '0.2.2-alpha': '0.16.0-beta',

--- a/src/utils/tests/helpers.ts
+++ b/src/utils/tests/helpers.ts
@@ -156,9 +156,16 @@ export const testRepoState: DockerRepoState = {
       versions: [],
     },
     tapd: {
-      latest: '0.3.1-alpha',
-      versions: ['0.3.1-alpha', '0.2.3-alpha', '0.2.2-alpha', '0.2.0-alpha'],
+      latest: '0.3.2-alpha',
+      versions: [
+        '0.3.2-alpha',
+        '0.3.1-alpha',
+        '0.2.3-alpha',
+        '0.2.2-alpha',
+        '0.2.0-alpha',
+      ],
       compatibility: {
+        '0.3.2-alpha': '0.16.0-beta',
         '0.3.1-alpha': '0.16.0-beta',
         '0.3.0-alpha': '0.16.0-beta',
         '0.2.3-alpha': '0.16.0-beta',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2216,10 +2216,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@lightningpolar/tapd-api@0.3.0-alpha.rc1":
-  version "0.3.0-alpha.rc1"
-  resolved "https://registry.yarnpkg.com/@lightningpolar/tapd-api/-/tapd-api-0.3.0-alpha.rc1.tgz#3d2982db45d900c7706136fe2d4b7f73a5604380"
-  integrity sha512-MYuUCrdgol2nFLFk743c4fzdRXx6jXMwU8hKl7arAOjW9hdVWg/nk5qmj8Jwxvi1nsHc3A1H3MdHG8Ep2Pc7lA==
+"@lightningpolar/tapd-api@0.3.1-alpha":
+  version "0.3.1-alpha"
+  resolved "https://registry.yarnpkg.com/@lightningpolar/tapd-api/-/tapd-api-0.3.1-alpha.tgz#c27f56fba00aa178566415738bc26c5cad2ff48f"
+  integrity sha512-EM6qeUYppZL1VgaHhFbCC2Dx9PMLg/SreItqXd+CyJMjUgJU5hS5F5rwWDkZf9q8ZeH2yF7+3hN/EiUAeB2HHg==
   dependencies:
     "@grpc/grpc-js" "1.7.2"
     "@grpc/proto-loader" "0.7.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2216,10 +2216,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@lightningpolar/tapd-api@0.3.2-alpha":
-  version "0.3.2-alpha"
-  resolved "https://registry.yarnpkg.com/@lightningpolar/tapd-api/-/tapd-api-0.3.2-alpha.tgz#263b699d8ce38276c645304a60dd1143a4aedc59"
-  integrity sha512-XOjR6VEDEb/d9UkcS/LeiqNwI1iRNtU/BrCZdBUghjhb9bO7En5tTMvypmduRbFAdvkC/NxAbOTatTVKTPO4Zg==
+"@lightningpolar/tapd-api@^0.3.3-alpha":
+  version "0.3.3-alpha"
+  resolved "https://registry.yarnpkg.com/@lightningpolar/tapd-api/-/tapd-api-0.3.3-alpha.tgz#9f9664f1e6c47cd09592b25d85d05be1a8d97d24"
+  integrity sha512-hsHCYljia7QQmi0rIAtJToTW0YxWKDdorpiDCgPOduhihfbZ9veknNY7+dQbI7DWRSQKJJrcp0IbXzGD4ghQpw==
   dependencies:
     "@grpc/grpc-js" "1.7.2"
     "@grpc/proto-loader" "0.7.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2216,10 +2216,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@lightningpolar/tapd-api@0.3.1-alpha":
-  version "0.3.1-alpha"
-  resolved "https://registry.yarnpkg.com/@lightningpolar/tapd-api/-/tapd-api-0.3.1-alpha.tgz#c27f56fba00aa178566415738bc26c5cad2ff48f"
-  integrity sha512-EM6qeUYppZL1VgaHhFbCC2Dx9PMLg/SreItqXd+CyJMjUgJU5hS5F5rwWDkZf9q8ZeH2yF7+3hN/EiUAeB2HHg==
+"@lightningpolar/tapd-api@0.3.2-alpha":
+  version "0.3.2-alpha"
+  resolved "https://registry.yarnpkg.com/@lightningpolar/tapd-api/-/tapd-api-0.3.2-alpha.tgz#263b699d8ce38276c645304a60dd1143a4aedc59"
+  integrity sha512-XOjR6VEDEb/d9UkcS/LeiqNwI1iRNtU/BrCZdBUghjhb9bO7En5tTMvypmduRbFAdvkC/NxAbOTatTVKTPO4Zg==
   dependencies:
     "@grpc/grpc-js" "1.7.2"
     "@grpc/proto-loader" "0.7.3"


### PR DESCRIPTION
### Description

Adds support for `tapd` v0.3.3-alpha. There was a change in the `universerpc.AssetRoots` RPC which broke syncing universes in Polar. A new version of Polar will be necessary to run this `tapd` version. I'll hold off on merging this until the release is ready to ship.
