### PR TITLE
feat(dev): add devcontainers support

### DIFF
--- a/.devcontainer/Dockerfile-headless
+++ b/.devcontainer/Dockerfile-headless
@@ -1,0 +1,32 @@
+FROM debian
+
+ARG NODE_VERSION=20.1
+ENV DEBIAN_FRONTEND=noninteractive
+ENV USER_NAME=dev
+
+# install some development packages
+RUN apt-get update -y && \
+  apt-get install -y apt-utils binutils curl git gnupg less python3 rpm
+
+# install yarn
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+  echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list && \
+  apt update -y && \
+  apt install -y --no-install-recommends yarn
+
+# workdir
+RUN mkdir /app && chown 1000:1000 /app
+WORKDIR /app
+
+# create non-root user and switch to it from here on
+RUN useradd -m -u 1000 -U -s /bin/bash ${USER_NAME}
+USER ${USER_NAME}
+
+# install nvm
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+
+# install node 16.20.2
+RUN bash -c '. ~/.nvm/nvm.sh && nvm install ${NODE_VERSION}'
+
+# add node to PATH
+ENV PATH=/home/${USER_NAME}/.nvm/versions/node/${NODE_VERSION}/bin:$PATH

--- a/.devcontainer/Dockerfile-ui
+++ b/.devcontainer/Dockerfile-ui
@@ -1,0 +1,37 @@
+# replace the base image with the image matching the file Dockerfile-headless
+FROM polardev:headless
+
+# GRAPHICAL UI
+#
+# From here on, we set up the container to be able to forward graphical UI
+# to the host machine using X11. These steps are not necessary if the developer
+# just want to install, test and compile Polar (headless mode).
+
+# switch to root user to install dependencies
+USER root
+
+# Install dependencies to forward graphical UI on host to the container.
+# chromium needs to be installed because Electron depends on it.
+RUN apt-get install \
+  -y --no-install-suggests --no-install-recommends \
+  chromium x11-xserver-utils
+
+# Install docker in order connect to docker daemon on host via unix socket.
+RUN apt install -y apt-transport-https ca-certificates software-properties-common && \
+  curl -fsSL https://download.docker.com/linux/debian/gpg | \
+  gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg && \
+  echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian bullseye stable" | \
+  tee /etc/apt/sources.list.d/docker.list > /dev/null && \
+  apt-get update -y && \
+  apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose
+
+# Docker GID depends on OS: 996 on ArchLinux, 969 on debian, 999 on ubuntu.
+# One can run `grep docker /etc/group` to figure out the Docker's GID.
+# Developer may need to change it here...
+ARG DOCKER_GID=969
+
+# change docker gid in the container and add non-root user to this group
+RUN groupmod --gid ${DOCKER_GID} docker && usermod -aG ${DOCKER_GID} ${USER_NAME}
+
+# switch to the non-root user
+USER ${USER_NAME}

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,27 @@
+# DEVCONTAINERS
+
+You can build the images yourself or can pull the images in this directory:
+
+```bash
+docker pull polarlightning/dev:headless
+docker pull polarlightning/dev:ui
+```
+
+To build the images manually, run the following commands from the project root dir:
+
+```bash
+cd .devcontainers/
+docker image build --tag polardev:headless --file Dockerfile-headless .
+docker image build --tag polardev:ui --file Dockerfile-ui .
+```
+
+Make sure to use the same image names for the `--tag` flag because the file
+`Dockerfile-ui` is based on a image called `polardev:headless`. You can retag
+them after building the images:
+
+```
+docker image polardev:headless polardev
+```
+
+In the last example, we add the tag name `polardev` to reference the same image
+as the one tagged by `polardev:headless`.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-dockerfile
+{
+  "name": "Existing Dockerfile",
+  "build": {
+    // Sets the run context to one level up instead of the .devcontainer folder.
+    "context": ".",
+    "args": {
+      // "DOCKER_GID": "969"
+    },
+    // Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+    "dockerfile": "Dockerfile-headless"
+  },
+
+  // The path of the workspace folder inside the container.
+  "workspaceFolder": "/app",
+
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  // "features": {},
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  "forwardPorts": [3000]
+
+  // Uncomment the next line to run commands after the container is created.
+  // "postCreateCommand": "cat /etc/os-release",
+
+  // Configure tool-specific properties.
+  // "customizations": {}
+
+  // Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.
+  // "remoteUser": "devcontainer"
+}


### PR DESCRIPTION
Development feature: automate the setup of development environment via devcontainers.

This facilitates developing Polar by configuring a reproducible environment to build, test and develop.

The devcontainers specification can be integrated into IDEs like Vscode/Vscodium.
Alternativaley, it is possible to manually create a container and run commands inside of it.

