### PR TITLE
feat: add xdg support

### DIFF
--- a/e2e/helpers/index.ts
+++ b/e2e/helpers/index.ts
@@ -1,7 +1,6 @@
 import { remove } from 'fs-extra';
-import { join } from 'path';
-import { homedir } from 'os';
 import { ClientFunction } from 'testcafe';
+import { networksPath } from '../../src/utils/config';
 
 export const pageUrl = '../build/index.html';
 
@@ -14,5 +13,5 @@ export const assertNoConsoleErrors = async (t: TestController) => {
 };
 
 export const cleanup = async () => {
-  await remove(join(homedir(), '.polar', 'networks'));
+  await remove(networksPath);
 };

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -3,6 +3,7 @@ import log from 'electron-log';
 import { join } from 'path';
 import http from 'http';
 import https from 'https';
+import { existsSync } from 'fs';
 
 /**
  * setup logging to store log files in ~/.polar/logs/ dir
@@ -10,7 +11,10 @@ import https from 'https';
 export const initLogger = () => {
   log.transports.file.resolvePath = (variables: log.PathVariables) => {
     const ap = app || remote.app;
-    return join(ap.getPath('home'), '.polar', 'logs', variables.fileName as string);
+    const home = ap.getPath('home');
+    const xdgPath = join(home, '.local', 'share', 'polar');
+    const dataPath = existsSync(xdgPath) ? xdgPath : join(home, '.polar');
+    return join(dataPath, 'logs', variables.fileName as string);
   };
 };
 

--- a/src/utils/config.spec.ts
+++ b/src/utils/config.spec.ts
@@ -1,0 +1,45 @@
+describe('Config utils', () => {
+  // stores the config module.
+  let ConfigModule: any;
+
+  // mock options before loading the config module.
+  type mockOptions = {
+    mockXdg?: boolean;
+  };
+
+  // (re)loads the config module for the new options to take effect.
+  async function loadConfigModule(mockOptions: mockOptions = {}) {
+    // reset modules
+    jest.resetModules();
+
+    // mock fs, which affect the config utils module.
+    jest.mock('fs', () => ({
+      existsSync: jest.fn(() => mockOptions.mockXdg === true),
+    }));
+
+    // import config module.
+    await import('./config').then(module => {
+      ConfigModule = module;
+    });
+  }
+
+  describe('directory path', () => {
+    it('should place network directory inside data directory', async () => {
+      await loadConfigModule();
+      const { dataPath, networksPath } = ConfigModule;
+      expect(networksPath).toContain(dataPath);
+    });
+
+    it('should use XDG directory as Data directory if it exists', async () => {
+      await loadConfigModule({ mockXdg: true });
+      const { dataPath, xdgDataPath } = ConfigModule;
+      expect(dataPath).toBe(xdgDataPath);
+    });
+
+    it('should not use XDG directory as Data directory if it does not exists', async () => {
+      await loadConfigModule({ mockXdg: false });
+      const { dataPath, xdgDataPath } = ConfigModule;
+      expect(dataPath).not.toBe(xdgDataPath);
+    });
+  });
+});

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -3,11 +3,19 @@ import { join } from 'path';
 import { NodeImplementation } from 'shared/types';
 import { Network } from 'types';
 import { dockerConfigs } from './constants';
+import { existsSync } from 'fs';
+
+/**
+ * XDG-compliant path where application data is stored
+ */
+export const xdgDataPath = join(remote.app.getPath('home'), '.local', 'share', 'polar');
 
 /**
  * root path where application data is stored
  */
-export const dataPath = join(remote.app.getPath('home'), '.polar');
+export const dataPath = existsSync(xdgDataPath)
+  ? xdgDataPath
+  : join(remote.app.getPath('home'), '.polar');
 
 /**
  * legacy path where application data was stored in v0.1.0
@@ -20,7 +28,7 @@ export const legacyDataPath = join(remote.app.getPath('userData'), 'data');
 export const networksPath = join(dataPath, 'networks');
 
 /**
- * returns a path to store dtat for an individual node
+ * returns a path to store data for an individual node
  */
 export const nodePath = (
   network: Network,


### PR DESCRIPTION
## Description

If and only if `~/.local/share/polar` exists, Polar will use it to store application data instead of `~/.polar`, abiding to the XDG specification (see https://wiki.archlinux.org/title/XDG_user_directories).

This is a backwards compatible update: users who have their data at `~/.polar` will NOT be affected. The `~/.local/share/polar` XDG-compliant directory is not created automatically and the user must create it manually to enable the new feature.

## Note

I tried to import `dataPath` from `src/utils/config` in `src/shared/utils` to avoid code duplication but it wouldn't compile and would complain `cannot resolve module 'utils/config'`. I tried to use a relative import, `import { dataPath } from '../utils/config'`, but the compiler would throw similar errors (it would not resolve `shared/<filename>` imports inside `../utils/config`). Therefore, there is some duplicated code.

