### PR TITLE
Fix: Bug: Eclair - Error in GUI when open channel #804

### DIFF
--- a/src/lib/lightning/eclair/eclairService.spec.ts
+++ b/src/lib/lightning/eclair/eclairService.spec.ts
@@ -74,20 +74,28 @@ describe('EclairService', () => {
       state: ELN.ChannelState.NORMAL,
       data: {
         commitments: {
-          channelFlags: 1,
-          localParams: {
-            isFunder: true,
-            isInitiator: undefined as any,
-          },
-          localCommit: {
-            spec: {
-              toLocal: 100000000,
-              toRemote: 50000000,
+          params: {
+            localParams: {
+              isFunder: true,
+              isInitiator: undefined as any,
+            },
+            channelFlags: {
+              announceChannel: true,
             },
           },
-          commitInput: {
-            amountSatoshis: 150000,
-          },
+          active: [
+            {
+              fundingTx: {
+                amountSatoshis: 150000,
+              },
+              localCommit: {
+                spec: {
+                  toLocal: 100000000,
+                  toRemote: 50000000,
+                },
+              },
+            },
+          ],
         },
       },
     };
@@ -104,20 +112,28 @@ describe('EclairService', () => {
       state: ELN.ChannelState.NORMAL,
       data: {
         commitments: {
-          channelFlags: 1,
-          localParams: {
-            isFunder: undefined as any,
-            isInitiator: true,
-          },
-          localCommit: {
-            spec: {
-              toLocal: 100000000,
-              toRemote: 50000000,
+          params: {
+            localParams: {
+              isFunder: undefined as any,
+              isInitiator: true,
+            },
+            channelFlags: {
+              announceChannel: true,
             },
           },
-          commitInput: {
-            amountSatoshis: 150000,
-          },
+          active: [
+            {
+              fundingTx: {
+                amountSatoshis: 150000,
+              },
+              localCommit: {
+                spec: {
+                  toLocal: 100000000,
+                  toRemote: 50000000,
+                },
+              },
+            },
+          ],
         },
       },
     };

--- a/src/lib/lightning/eclair/eclairService.spec.ts
+++ b/src/lib/lightning/eclair/eclairService.spec.ts
@@ -67,7 +67,8 @@ describe('EclairService', () => {
     expect(actual).toEqual(expected);
   });
 
-  it('should get a list of channels for < v0.8.0', async () => {
+  it('should get a list of channels for v0.7.0', async () => {
+    node.version = '0.7.0';
     const chanResponse: ELN.ChannelResponse = {
       nodeId: 'abcdef',
       channelId: '65sdfd7',
@@ -76,26 +77,41 @@ describe('EclairService', () => {
         commitments: {
           params: {
             localParams: {
-              isFunder: true,
-              isInitiator: undefined as any,
+              isInitiator: false,
             },
             channelFlags: {
-              announceChannel: true,
+              announceChannel: false,
             },
           },
           active: [
             {
               fundingTx: {
-                amountSatoshis: 150000,
+                amountSatoshis: 0,
               },
               localCommit: {
                 spec: {
-                  toLocal: 100000000,
-                  toRemote: 50000000,
+                  toLocal: 0,
+                  toRemote: 0,
                 },
               },
             },
           ],
+          localParams: {
+            isFunder: true,
+            isInitiator: false,
+          },
+          channelFlags: {
+            announceChannel: true,
+          },
+          localCommit: {
+            spec: {
+              toLocal: 250000000,
+              toRemote: 0,
+            },
+          },
+          commitInput: {
+            amountSatoshis: 250000,
+          },
         },
       },
     };
@@ -105,7 +121,8 @@ describe('EclairService', () => {
     expect(actual).toEqual(expected);
   });
 
-  it('should get a list of channels for >= v0.8.0', async () => {
+  it('should get a list of channels for v0.8.0', async () => {
+    node.version = '0.8.0';
     const chanResponse: ELN.ChannelResponse = {
       nodeId: 'abcdef',
       channelId: '65sdfd7',
@@ -114,7 +131,60 @@ describe('EclairService', () => {
         commitments: {
           params: {
             localParams: {
-              isFunder: undefined as any,
+              isInitiator: false,
+            },
+            channelFlags: {
+              announceChannel: false,
+            },
+          },
+          active: [
+            {
+              fundingTx: {
+                amountSatoshis: 0,
+              },
+              localCommit: {
+                spec: {
+                  toLocal: 0,
+                  toRemote: 0,
+                },
+              },
+            },
+          ],
+          localParams: {
+            isFunder: false,
+            isInitiator: true,
+          },
+          channelFlags: {
+            announceChannel: true,
+          },
+          localCommit: {
+            spec: {
+              toLocal: 250000000,
+              toRemote: 0,
+            },
+          },
+          commitInput: {
+            amountSatoshis: 250000,
+          },
+        },
+      },
+    };
+    eclairApiMock.httpPost.mockResolvedValue([chanResponse]);
+    const expected = [expect.objectContaining({ pubkey: 'abcdef' })];
+    const actual = await eclairService.getChannels(node);
+    expect(actual).toEqual(expected);
+  });
+
+  it('should get a list of channels for >= v0.9.0', async () => {
+    node.version = '0.9.0';
+    const chanResponse: ELN.ChannelResponse = {
+      nodeId: 'abcdef',
+      channelId: '65sdfd7',
+      state: ELN.ChannelState.NORMAL,
+      data: {
+        commitments: {
+          params: {
+            localParams: {
               isInitiator: true,
             },
             channelFlags: {
@@ -124,16 +194,32 @@ describe('EclairService', () => {
           active: [
             {
               fundingTx: {
-                amountSatoshis: 150000,
+                amountSatoshis: 250000,
               },
               localCommit: {
                 spec: {
-                  toLocal: 100000000,
-                  toRemote: 50000000,
+                  toLocal: 250000000,
+                  toRemote: 0,
                 },
               },
             },
           ],
+          localParams: {
+            isFunder: false,
+            isInitiator: false,
+          },
+          channelFlags: {
+            announceChannel: false,
+          },
+          localCommit: {
+            spec: {
+              toLocal: 0,
+              toRemote: 0,
+            },
+          },
+          commitInput: {
+            amountSatoshis: 0,
+          },
         },
       },
     };

--- a/src/lib/lightning/eclair/types.ts
+++ b/src/lib/lightning/eclair/types.ts
@@ -44,12 +44,10 @@ type ChannelFlags = 0 | 1;
  * https://acinq.github.io/eclair/#channel
  */
 interface ChannelData {
+  // ChannelData interface has some repeated fields to be compatible with v0.9.0, 0.8.0 and 0.7.0 versions
   commitments: {
     params: {
       localParams: {
-        // The isFunder field was renamed to isInitiator in v0.8.0. We use both
-        // to maintain compatibility with older versions.
-        isFunder: boolean;
         isInitiator: boolean;
       };
       channelFlags: {
@@ -69,6 +67,23 @@ interface ChannelData {
         };
       },
     ];
+    localParams: {
+      // The isFunder field was renamed to isInitiator in v0.8.0+
+      isFunder: boolean;
+      isInitiator: boolean;
+    };
+    channelFlags: {
+      announceChannel: boolean;
+    };
+    localCommit: {
+      spec: {
+        toLocal: number;
+        toRemote: number;
+      };
+    };
+    commitInput: {
+      amountSatoshis: number;
+    };
   };
 }
 

--- a/src/lib/lightning/eclair/types.ts
+++ b/src/lib/lightning/eclair/types.ts
@@ -45,22 +45,30 @@ type ChannelFlags = 0 | 1;
  */
 interface ChannelData {
   commitments: {
-    localParams: {
-      // The isFunder field was renamed to isInitiator in v0.8.0. We use both
-      // to maintain compatibility with older versions.
-      isFunder: boolean;
-      isInitiator: boolean;
-    };
-    channelFlags: ChannelFlags;
-    localCommit: {
-      spec: {
-        toLocal: number;
-        toRemote: number;
+    params: {
+      localParams: {
+        // The isFunder field was renamed to isInitiator in v0.8.0. We use both
+        // to maintain compatibility with older versions.
+        isFunder: boolean;
+        isInitiator: boolean;
+      };
+      channelFlags: {
+        announceChannel: boolean;
       };
     };
-    commitInput: {
-      amountSatoshis: number;
-    };
+    active: [
+      {
+        fundingTx: {
+          amountSatoshis: number;
+        };
+        localCommit: {
+          spec: {
+            toLocal: number;
+            toRemote: number;
+          };
+        };
+      },
+    ];
   };
 }
 


### PR DESCRIPTION
This PR Closes #804

Some [ChannelData](https://github.com/jamaljsr/polar/blob/master/src/lib/lightning/eclair/types.ts#L46) properties for the Eclair node was updated for v0.9.0 when calling its [API](https://acinq.github.io/eclair/#channels-2) and this caused a bug when running that version. 

This PR updates the ChannelData properties to be compatible with v0.9.0, v0.8.0 and v0.7.0.