### PR TITLE
fix(OpenChannelModal): added default value for isPrivate checkbox

### DIFF
--- a/src/components/designer/lightning/actions/OpenChannelModal.spec.tsx
+++ b/src/components/designer/lightning/actions/OpenChannelModal.spec.tsx
@@ -198,6 +198,7 @@ describe('OpenChannelModal', () => {
         from: node2,
         toRpcUrl: 'asdf@host',
         amount: 1000,
+        isPrivate: false,
       });
       expect(bitcoindServiceMock.mine).toBeCalledTimes(1);
     });
@@ -217,6 +218,7 @@ describe('OpenChannelModal', () => {
         from: node2,
         toRpcUrl: 'asdf@host',
         amount: 1000,
+        isPrivate: false,
       });
       expect(bitcoindServiceMock.mine).toBeCalledTimes(2);
       expect(bitcoindServiceMock.sendFunds).toBeCalledTimes(1);

--- a/src/components/designer/lightning/actions/OpenChannelModal.tsx
+++ b/src/components/designer/lightning/actions/OpenChannelModal.tsx
@@ -87,7 +87,7 @@ const OpenChannelModal: React.FC<Props> = ({ network }) => {
       layout="vertical"
       hideRequiredMark
       colon={false}
-      initialValues={{ from, to, sats: 250000, autoFund: true }}
+      initialValues={{ from, to, sats: 250000, autoFund: true, isPrivate: false }}
       onFinish={handleSubmit}
     >
       {sameNode && <Alert type="error" message={l('sameNodesWarnMsg')} />}


### PR DESCRIPTION

### Description

When you try to open a channel, the OpenChannelModal pops up and the checked box for `isPrivate` is unchecked - this should translate to false but it's undefined because it doesn't have a default value.

This PR fixes the default value for isPrivate to false.
