### PR TITLE
feat(images): add support for LND v0.18.0-beta.rc1

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -48,6 +48,7 @@ Replace `<version>` with the desired bitcoind version (ex: `0.18.1`)
 
 ### Tags
 
+- `0.18.0-beta.rc1` ([lnd/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/lnd/Dockerfile))
 - `0.17.5-beta` ([lnd/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/lnd/Dockerfile))
 - `0.17.4-beta` ([lnd/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/lnd/Dockerfile))
 - `0.17.3-beta` ([lnd/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/lnd/Dockerfile))

--- a/docker/nodes.json
+++ b/docker/nodes.json
@@ -1,9 +1,10 @@
 {
-  "version": 58,
+  "version": 59,
   "images": {
     "LND": {
       "latest": "0.17.5-beta",
       "versions": [
+        "0.18.0-beta.rc1",
         "0.17.5-beta",
         "0.17.4-beta",
         "0.17.3-beta",
@@ -19,6 +20,7 @@
         "0.13.1-beta"
       ],
       "compatibility": {
+        "0.18.0-beta.rc1": "27.0",
         "0.17.5-beta": "27.0",
         "0.17.4-beta": "27.0",
         "0.17.3-beta": "27.0",

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -255,11 +255,12 @@ export const REPO_STATE_URL =
  * are pushed to Docker Hub, this list should be updated along with the /docker/nodes.json file.
  */
 export const defaultRepoState: DockerRepoState = {
-  version: 58,
+  version: 59,
   images: {
     LND: {
       latest: '0.17.5-beta',
       versions: [
+        '0.18.0-beta.rc1',
         '0.17.5-beta',
         '0.17.4-beta',
         '0.17.3-beta',
@@ -277,6 +278,7 @@ export const defaultRepoState: DockerRepoState = {
       // not all LND versions are compatible with all bitcoind versions.
       // this mapping specifies the highest compatible bitcoind for each LND version
       compatibility: {
+        '0.18.0-beta.rc1': '27.0',
         '0.17.5-beta': '27.0',
         '0.17.4-beta': '27.0',
         '0.17.3-beta': '27.0',


### PR DESCRIPTION
Add support for LND v0.18.0-beta.rc1. The docker image has already been pushed to Docker Hub.