### PR TITLE
feat: remember node counts when creating new networks

### DIFF
--- a/src/components/network/NewNetwork.spec.tsx
+++ b/src/components/network/NewNetwork.spec.tsx
@@ -83,9 +83,7 @@ describe('NewNetwork component', () => {
   it('should disable c-lightning input on Windows', () => {
     mockOS.platform.mockReturnValue('win32');
     const { getByLabelText, getByText } = renderComponent();
-    expect(getByLabelText('Core Lightning')).toHaveValue('0');
-    expect(getByLabelText('LND')).toHaveValue('2');
-    expect(getByLabelText('Eclair')).toHaveValue('1');
+    expect(getByLabelText('Core Lightning')).toBeDisabled();
     expect(getByText('Not supported on Windows yet.')).toBeInTheDocument();
   });
 

--- a/src/components/network/NewNetwork.tsx
+++ b/src/components/network/NewNetwork.tsx
@@ -73,10 +73,10 @@ const NewNetwork: React.FC = () => {
           layout="vertical"
           colon={false}
           initialValues={{
-            lndNodes: isWindows() ? 2 : 1,
-            clightningNodes: isWindows() ? 0 : 1,
-            eclairNodes: 1,
-            bitcoindNodes: 1,
+            lndNodes: settings.newNodeCounts.LND,
+            clightningNodes: settings.newNodeCounts['c-lightning'],
+            eclairNodes: settings.newNodeCounts.eclair,
+            bitcoindNodes: settings.newNodeCounts.bitcoind,
             customNodes: initialCustomValues,
           }}
           onFinish={createAsync.execute}

--- a/src/lib/settings/settingsService.spec.ts
+++ b/src/lib/settings/settingsService.spec.ts
@@ -20,6 +20,14 @@ describe('SettingsService', () => {
       checkForUpdatesOnStartup: false,
       theme: 'dark',
       nodeImages: { custom: [], managed: [] },
+      newNodeCounts: {
+        LND: 1,
+        'c-lightning': 1,
+        eclair: 1,
+        bitcoind: 1,
+        btcd: 0,
+        tapd: 0,
+      },
     };
   });
 

--- a/src/store/models/app.ts
+++ b/src/store/models/app.ts
@@ -17,6 +17,7 @@ import {
   StoreInjections,
 } from 'types';
 import { defaultRepoState } from 'utils/constants';
+import { isWindows } from 'utils/system';
 import { changeTheme } from 'utils/theme';
 import { NETWORK_VIEW } from 'components/routing';
 import { RootModel } from './';
@@ -79,6 +80,14 @@ const appModel: AppModel = {
       managed: [],
       custom: [],
     },
+    newNodeCounts: {
+      LND: 1,
+      'c-lightning': 1,
+      eclair: 1,
+      bitcoind: 1,
+      btcd: 0,
+      tapd: 0,
+    },
   },
   dockerVersions: { docker: '', compose: '' },
   dockerImages: [],
@@ -123,7 +132,18 @@ const appModel: AppModel = {
       ...settings,
     };
   }),
-  loadSettings: thunk(async (actions, _, { injections }) => {
+  loadSettings: thunk(async (actions, _, { injections, getState }) => {
+    // before loading settings, set the default CLN count to 0 on Windows
+    if (isWindows()) {
+      actions.setSettings({
+        newNodeCounts: {
+          ...getState().settings.newNodeCounts,
+          LND: 2,
+          'c-lightning': 0,
+        },
+      });
+    }
+
     const settings = await injections.settingsService.load();
     if (settings) {
       actions.setSettings(settings);

--- a/src/store/models/network.ts
+++ b/src/store/models/network.ts
@@ -278,6 +278,18 @@ const networkModel: NetworkModel = {
       getStoreActions().designer.setChart({ id: newNetwork.id, chart });
       getStoreActions().designer.setActiveId(newNetwork.id);
       await actions.save();
+
+      await getStoreActions().app.updateSettings({
+        newNodeCounts: {
+          LND: lndNodes,
+          'c-lightning': clightningNodes,
+          eclair: eclairNodes,
+          bitcoind: bitcoindNodes,
+          btcd: 0,
+          tapd: 0,
+        },
+      });
+
       dispatch(push(NETWORK_VIEW(newNetwork.id)));
     },
   ),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -60,6 +60,8 @@ export interface AppSettings {
     managed: ManagedImage[];
     custom: CustomImage[];
   };
+  /** The default number of each node when creating a new network */
+  newNodeCounts: Record<NodeImplementation, number>;
 }
 
 export interface SettingsInjection {


### PR DESCRIPTION
### Description

When repeatedly creating new networks for testing, I often want to use the same count of nodes that I used on the previously created network. It's a minor annoyance to have to change the counts each time. This PR just saves the node counts when you create a new network and uses those values the next time you go to the _New Network_ screen. 

### Steps to Test

1. Click _New Network_
2. Change the node counts to different values
3. Click _Create Network_
4. Delete the network
5. Restart Polar
6. Click _New Network_
7. Confirm the initial node counts are what you previously set

