### PR TITLE
feat(images): add support for tapd v0.4.1 and litd v0.13.991

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Supported Network Node Versions:
 - [Core Lightning](https://github.com/ElementsProject/lightning) - v24.05, v24.02.2, v23.11.2
 - [Eclair](https://github.com/ACINQ/eclair/) - v0.10.0, v0.9.0, v0.8.0, v0.7.0, v0.6.2, v0.5.0
 - [Bitcoin Core](https://github.com/bitcoin/bitcoin) - v27.0, v26.0, v25.0, v24.0, v23.0, v22.0, v0.21.1
-- [Taproot Assets](https://github.com/lightninglabs/taproot-assets) - v0.4.0, v0.3.3, v0.3.2
+- [Taproot Assets](https://github.com/lightninglabs/taproot-assets) - v0.4.1, v0.4.0, v0.3.3, v0.3.2
 - [Terminal](https://github.com/lightninglabs/lightning-terminal) - v0.13.99
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Supported Network Node Versions:
 - [Eclair](https://github.com/ACINQ/eclair/) - v0.10.0, v0.9.0, v0.8.0, v0.7.0, v0.6.2, v0.5.0
 - [Bitcoin Core](https://github.com/bitcoin/bitcoin) - v27.0, v26.0, v25.0, v24.0, v23.0, v22.0, v0.21.1
 - [Taproot Assets](https://github.com/lightninglabs/taproot-assets) - v0.4.1, v0.4.0, v0.3.3, v0.3.2
-- [Terminal](https://github.com/lightninglabs/lightning-terminal) - v0.13.99
+- [Terminal](https://github.com/lightninglabs/lightning-terminal) - v0.13.991, v0.13.99
 
 ## Dependencies
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -156,6 +156,7 @@ Replace `<version>` with the desired Eclair version (ex: `0.3.3`).
 
 ### Tags
 
+- `0.4.1-alpha` ([tap/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/tapd/Dockerfile))
 - `0.4.0-alpha` ([tap/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/tapd/Dockerfile))
 - `0.3.3-alpha` ([tap/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/tapd/Dockerfile))
 - `0.3.2-alpha` ([tap/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/tapd/Dockerfile))

--- a/docker/README.md
+++ b/docker/README.md
@@ -179,7 +179,8 @@ Replace `<version>` with the desired Tap version (ex: `0.2.0-alpha`).
 
 ### Tags
 
-- `0.13.99-alpha` ([tap/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/tapd/Dockerfile))
+- `0.13.991-exp` ([tap/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/tapd/Dockerfile))
+- `0.13.99-exp` ([tap/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/tapd/Dockerfile))
 
 **Building the image**
 
@@ -188,7 +189,7 @@ $ cd litd
 $ docker buildx build --platform linux/amd64,linux/arm64 --build-arg LITD_VERSION=<version> -t polarlightning/litd:<version> --push .
 ```
 
-Replace `<version>` with the desired Tap version (ex: `0.12.5-alpha`).
+Replace `<version>` with the desired Tap version (ex: `0.13.3-alpha`).
 
 # Out-of-Band Image Updates
 

--- a/docker/nodes.json
+++ b/docker/nodes.json
@@ -1,5 +1,5 @@
 {
-  "version": 62,
+  "version": 63,
   "images": {
     "LND": {
       "latest": "0.18.2-beta",
@@ -37,18 +37,20 @@
       "versions": []
     },
     "tapd": {
-      "latest": "0.4.0-alpha",
-      "versions": ["0.4.0-alpha", "0.3.3-alpha", "0.3.2-alpha"],
+      "latest": "0.4.1-alpha",
+      "versions": ["0.4.1-alpha", "0.4.0-alpha", "0.3.3-alpha", "0.3.2-alpha"],
       "compatibility": {
+        "0.4.1-alpha": "0.18.0-beta",
         "0.4.0-alpha": "0.18.0-beta",
         "0.3.3-alpha": "0.16.0-beta",
         "0.3.2-alpha": "0.16.0-beta"
       }
     },
     "litd": {
-      "latest": "0.13.99-exp",
-      "versions": ["0.13.99-exp"],
+      "latest": "0.13.991-exp",
+      "versions": ["0.13.991-exp", "0.13.99-exp"],
       "compatibility": {
+        "0.13.991-exp": "27.0",
         "0.13.99-exp": "27.0"
       }
     }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -383,9 +383,10 @@ export const defaultRepoState: DockerRepoState = {
       },
     },
     litd: {
-      latest: '0.13.99-exp',
-      versions: ['0.13.99-exp'],
+      latest: '0.13.991-exp',
+      versions: ['0.13.991-exp', '0.13.99-exp'],
       compatibility: {
+        '0.13.991-exp': '27.0',
         '0.13.99-exp': '27.0',
       },
     },

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -371,11 +371,12 @@ export const defaultRepoState: DockerRepoState = {
       versions: [],
     },
     tapd: {
-      latest: '0.4.0-alpha',
-      versions: ['0.4.0-alpha', '0.3.3-alpha', '0.3.2-alpha'],
+      latest: '0.4.1-alpha',
+      versions: ['0.4.1-alpha', '0.4.0-alpha', '0.3.3-alpha', '0.3.2-alpha'],
       // Not all tapd versions are compatible with all LND versions.
       // This mapping specifies the minimum compatible LND for each tapd version
       compatibility: {
+        '0.4.1-alpha': '0.18.0-beta',
         '0.4.0-alpha': '0.18.0-beta',
         '0.3.3-alpha': '0.16.0-beta',
         '0.3.2-alpha': '0.16.0-beta',

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -331,7 +331,7 @@ export const REPO_STATE_URL =
  * are pushed to Docker Hub, this list should be updated along with the /docker/nodes.json file.
  */
 export const defaultRepoState: DockerRepoState = {
-  version: 62,
+  version: 63,
   images: {
     LND: {
       latest: '0.18.2-beta',

--- a/src/utils/tests/helpers.ts
+++ b/src/utils/tests/helpers.ts
@@ -171,21 +171,23 @@ export const testRepoState: DockerRepoState = {
       versions: [],
     },
     tapd: {
-      latest: '0.4.0-alpha',
-      versions: ['0.4.0-alpha', '0.3.3-alpha', '0.3.2-alpha'],
+      latest: '0.4.1-alpha',
+      versions: ['0.4.1-alpha', '0.4.0-alpha', '0.3.3-alpha', '0.3.2-alpha'],
       // Not all tapd versions are compatible with all LND versions.
       // This mapping specifies the minimum compatible LND for each tapd version
       compatibility: {
+        '0.4.1-alpha': '0.18.0-beta',
         '0.4.0-alpha': '0.18.0-beta',
         '0.3.3-alpha': '0.16.0-beta',
         '0.3.2-alpha': '0.16.0-beta',
       },
     },
     litd: {
-      latest: '0.13.99-alpha',
-      versions: ['0.13.99-alpha'],
+      latest: '0.13.991-exp',
+      versions: ['0.13.991-exp', '0.13.99-exp'],
       compatibility: {
-        '0.13.99-alpha': '27.0',
+        '0.13.991-exp': '27.0',
+        '0.13.99-exp': '27.0',
       },
     },
   },


### PR DESCRIPTION
Adds support for the following node versions:

- `tapd` v0.4.1-alpha  
- `litd` v0.13.991

The docker images have been pushed to Docker Hub.