### PR TITLE
fix: broken bitcoin-cli bash completion link

### DIFF
--- a/docker/bitcoind/Dockerfile
+++ b/docker/bitcoind/Dockerfile
@@ -13,7 +13,7 @@ RUN SYS_ARCH="$(uname -m)" \
   && tar -xzf *.tar.gz -C /opt \
   && rm *.tar.gz
 
-RUN curl -SLO https://raw.githubusercontent.com/bitcoin/bitcoin/master/contrib/bitcoin-cli.bash-completion \
+RUN curl -SLO https://raw.githubusercontent.com/bitcoin/bitcoin/master/contrib/completions/bash/bitcoin-cli.bash \
   && mkdir /etc/bash_completion.d \
   && mv bitcoin-cli.bash-completion /etc/bash_completion.d/ \
   && curl -SLO https://raw.githubusercontent.com/scop/bash-completion/master/bash_completion \


### PR DESCRIPTION
We replace the bitcoin-cli bash-completion source link with the actual link. The previous one is broken and returns 404.

Closes #(issue number goes here)

### Description

[Description of your changes go here. Please provide both casual and technical explanations.]

### Steps to Test

1. Steps
2. To
3. Test

### Screenshots

[Only if applicable]
