### PR TITLE
feat(images): add support for CLN v24.08

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ With Polar you can:
 Supported Network Node Versions:
 
 - [LND](https://github.com/lightningnetwork/lnd) - v0.18.0, v0.17.5, v0.17.4, v0.17.3, v0.17.2, v0.17.1, v0.17.0, v0.16.4, v0.16.2, v0.16.1, v0.16.0, v0.15.5, v0.14.3, v0.13.1
-- [Core Lightning](https://github.com/ElementsProject/lightning) - v24.05, v24.02.2, v23.11.2
+- [Core Lightning](https://github.com/ElementsProject/lightning) - v24.08, v24.05, v24.02.2, v23.11.2
 - [Eclair](https://github.com/ACINQ/eclair/) - v0.10.0, v0.9.0, v0.8.0, v0.7.0, v0.6.2, v0.5.0
 - [Bitcoin Core](https://github.com/bitcoin/bitcoin) - v27.0, v26.0, v25.0, v24.0, v23.0, v22.0, v0.21.1
 - [Taproot Assets](https://github.com/lightninglabs/taproot-assets) - v0.4.1, v0.4.0, v0.3.3, v0.3.2

--- a/docker/README.md
+++ b/docker/README.md
@@ -99,6 +99,7 @@ Replace `<version>` with the desired LND version (ex: `0.7.1-beta`)
 
 ### Tags
 
+- `24.08` ([clightning/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/clightning/Dockerfile))
 - `24.05` ([clightning/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/clightning/Dockerfile))
 - `24.02.2` ([clightning/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/clightning/Dockerfile))
 - `23.11.2` ([clightning/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/clightning/Dockerfile))

--- a/docker/nodes.json
+++ b/docker/nodes.json
@@ -1,5 +1,5 @@
 {
-  "version": 64,
+  "version": 65,
   "images": {
     "LND": {
       "latest": "0.18.2-beta",
@@ -21,8 +21,8 @@
       }
     },
     "c-lightning": {
-      "latest": "24.05",
-      "versions": ["24.05", "24.02.2", "23.11.2"]
+      "latest": "24.08",
+      "versions": ["24.08", "24.05", "24.02.2", "23.11.2"]
     },
     "eclair": {
       "latest": "0.10.0",

--- a/src/lib/lightning/clightning/clightningService.ts
+++ b/src/lib/lightning/clightning/clightningService.ts
@@ -164,7 +164,7 @@ export class CLightningService implements LightningService {
   }
 
   async closeChannel(node: LightningNode, channelPoint: string): Promise<any> {
-    // The unilateraltimeout option is added to force close the channel because CLN v24.05 has a compatibility issue with Eclair v0.10.0.
+    // The unilateraltimeout option is added to force close the channel because CLN v24.08 has a compatibility issue with Eclair v0.10.0.
     // It should be removed after the issue is fixed in subsequent versions for CLN or Eclair nodes.
     const body = { id: channelPoint, unilateraltimeout: 1 }; // close the channel unilaterally after 1 second
     await httpPost<CLN.CloseChannelResponse>(node, `close`, body);

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -331,7 +331,7 @@ export const REPO_STATE_URL =
  * are pushed to Docker Hub, this list should be updated along with the /docker/nodes.json file.
  */
 export const defaultRepoState: DockerRepoState = {
-  version: 64,
+  version: 65,
   images: {
     LND: {
       latest: '0.18.2-beta',
@@ -355,8 +355,8 @@ export const defaultRepoState: DockerRepoState = {
       },
     },
     'c-lightning': {
-      latest: '24.05',
-      versions: ['24.05', '24.02.2', '23.11.2'],
+      latest: '24.08',
+      versions: ['24.08', '24.05', '24.02.2', '23.11.2'],
     },
     eclair: {
       latest: '0.10.0',

--- a/src/utils/tests/helpers.ts
+++ b/src/utils/tests/helpers.ts
@@ -59,7 +59,7 @@ export const testCustomImages: CustomImage[] = [
 ];
 
 export const testRepoState: DockerRepoState = {
-  version: 49,
+  version: 50,
   images: {
     LND: {
       latest: '0.18.2-beta',
@@ -144,8 +144,8 @@ export const testRepoState: DockerRepoState = {
       },
     },
     'c-lightning': {
-      latest: '23.05.2',
-      versions: ['23.05.2', '23.02.2', '22.11', '0.12.0', '0.11.2', '0.10.2'],
+      latest: '24.08',
+      versions: ['24.08', '24.05', '24.02.2', '23.11.2'],
     },
     eclair: {
       latest: '0.10.0',


### PR DESCRIPTION
Adds support for Core Lightning Node version 24.08

The docker [images](https://hub.docker.com/layers/polarlightning/clightning/24.08/images/sha256-f90244b2b8f1454bfb1177adbdb7b33b8613dcbe58660f69443c35b272cb6549?context=explore) have been pushed to Docker Hub.