### PR TITLE
Fix: Docker user warning UID is greater than SYS_UID_MAX

### DIFF
--- a/docker/bitcoind/docker-entrypoint.sh
+++ b/docker/bitcoind/docker-entrypoint.sh
@@ -10,7 +10,7 @@ if ! id bitcoin > /dev/null 2>&1; then
 
   echo "adding user bitcoin ($USERID:$GROUPID)"
   groupadd -f -g $GROUPID bitcoin
-  useradd -r -u $USERID -g $GROUPID bitcoin
+  useradd -M -u $USERID -g $GROUPID bitcoin
   chown -R $USERID:$GROUPID /home/bitcoin
 fi
 

--- a/docker/clightning/docker-entrypoint.sh
+++ b/docker/clightning/docker-entrypoint.sh
@@ -13,7 +13,7 @@ if ! id clightning > /dev/null 2>&1; then
 
   echo "adding user clightning ($USERID:$GROUPID)"
   groupadd -f -g $GROUPID clightning
-  useradd -r -u $USERID -g $GROUPID clightning
+  useradd -M -u $USERID -g $GROUPID clightning
   # ensure correct ownership of user home dir
   mkdir -p /home/clightning
   chown -R $USERID:$GROUPID /home/clightning

--- a/docker/eclair/docker-entrypoint.sh
+++ b/docker/eclair/docker-entrypoint.sh
@@ -13,7 +13,7 @@ if ! id eclair > /dev/null 2>&1; then
 
   echo "adding user eclair ($USERID:$GROUPID)"
   groupadd -f -g $GROUPID eclair
-  useradd -r -u $USERID -g $GROUPID eclair
+  useradd -M -u $USERID -g $GROUPID eclair
   # ensure correct ownership of user home dir
   mkdir -p /home/eclair
   chown -R $USERID:$GROUPID /home/eclair
@@ -25,7 +25,7 @@ if [ "$1" = "polar-eclair" ]; then
   for arg in "$@"
   do
     if [ "${arg:0:21}" = "--server.public-ips.0" ]; then
-      # replace the hostname provided in this arg with the IP address of the containing 
+      # replace the hostname provided in this arg with the IP address of the containing
       # because Eclair v8+ began including the DNS hostname in the NodeAnnouncements and
       # LND throws an error when parsing these messages
       JAVA_OPTS="$JAVA_OPTS -Declair.server.public-ips.0=$(hostname -i)"

--- a/docker/litd/docker-entrypoint.sh
+++ b/docker/litd/docker-entrypoint.sh
@@ -10,7 +10,7 @@ if ! id litd > /dev/null 2>&1; then
 
   echo "adding user litd ($USERID:$GROUPID)"
   groupadd -f -g $GROUPID litd
-  useradd -r -u $USERID -g $GROUPID litd
+  useradd -M -u $USERID -g $GROUPID litd
   chown -R $USERID:$GROUPID /home/litd
 fi
 

--- a/docker/lnd/docker-entrypoint.sh
+++ b/docker/lnd/docker-entrypoint.sh
@@ -10,7 +10,7 @@ if ! id lnd > /dev/null 2>&1; then
 
   echo "adding user lnd ($USERID:$GROUPID)"
   groupadd -f -g $GROUPID lnd
-  useradd -r -u $USERID -g $GROUPID lnd
+  useradd -M -u $USERID -g $GROUPID lnd
   chown -R $USERID:$GROUPID /home/lnd
 fi
 

--- a/docker/tapd/docker-entrypoint.sh
+++ b/docker/tapd/docker-entrypoint.sh
@@ -10,7 +10,7 @@ if ! id tap > /dev/null 2>&1; then
 
   echo "adding user tap ($USERID:$GROUPID)"
   groupadd -f -g $GROUPID tap
-  useradd -r -u $USERID -g $GROUPID tap
+  useradd -M -u $USERID -g $GROUPID tap
   chown -R $USERID:$GROUPID /home/tap
 fi
 


### PR DESCRIPTION
### Description

Currently docker entrypoints create users as system users by using the `-r` flag of `useradd`:

https://github.com/jamaljsr/polar/blob/52dc3c320b41e01e32abc6fb61bbd1606ab46ef7/docker/bitcoind/docker-entrypoint.sh#L13

The default user uid is 1000 greater than `SYS_UID_MAX` resulting in the following warning:

```
useradd warning: bitcoin's uid 1000 is greater than SYS_UID_MAX 999
```

To fix the warning:
- The `-r` flag was removed.
  - That flag also avoid home directory creation and password aging information in /etc/shadow.
- The `-M` flag was added to avoid home directory creation.
- And the password aging information is not necessary because the user has no password.

### References
- https://linux.die.net/man/8/useradd
- https://github.com/dotnet/dotnet-docker/pull/4676
  - Another project with the same issue.