### PR TITLE
Update node implementations to their latest versions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -68,5 +68,6 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"
   },
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "conventionalCommits.scopes": ["images"]
 }

--- a/docker/README.md
+++ b/docker/README.md
@@ -161,6 +161,7 @@ Replace `<version>` with the desired Eclair version (ex: `0.3.3`).
 
 ### Tags
 
+- `0.5.0-rc2` ([tap/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/tapd/Dockerfile))
 - `0.5.0-rc1` ([tap/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/tapd/Dockerfile))
 - `0.4.1-alpha` ([tap/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/tapd/Dockerfile))
 - `0.4.0-alpha` ([tap/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/tapd/Dockerfile))

--- a/docker/README.md
+++ b/docker/README.md
@@ -186,7 +186,8 @@ Replace `<version>` with the desired Tap version (ex: `0.2.0-alpha`).
 
 ### Tags
 
-- `0.14.0-alpha.rc1` ([tap/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/tapd/Dockerfile))
+- `0.14.0-alpha.rc2` ([litd/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/litd/Dockerfile))
+- `0.14.0-alpha.rc1` ([litd/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/litd/Dockerfile))
 
 **Building the image**
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -103,6 +103,7 @@ Replace `<version>` with the desired LND version (ex: `0.7.1-beta`)
 
 ### Tags
 
+- `24.11` ([clightning/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/clightning/Dockerfile))
 - `24.08.1` ([clightning/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/clightning/Dockerfile))
 - `24.08` ([clightning/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/clightning/Dockerfile))
 - `24.05` ([clightning/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/clightning/Dockerfile))

--- a/docker/README.md
+++ b/docker/README.md
@@ -49,6 +49,7 @@ Replace `<version>` with the desired bitcoind version (ex: `0.18.1`)
 
 ### Tags
 
+- `0.18.4-beta.rc2` ([lnd/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/lnd/Dockerfile))
 - `0.18.4-beta.rc1` ([lnd/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/lnd/Dockerfile))
 - `0.18.3-beta` ([lnd/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/lnd/Dockerfile))
 - `0.18.2-beta` ([lnd/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/lnd/Dockerfile))
@@ -93,7 +94,7 @@ Replace `<version>` with the desired bitcoind version (ex: `0.18.1`)
 
 ```sh
 $ cd lnd
-$ docker buildx build --platform linux/amd64,linux/arm64 --build-arg LND_VERSION=0.18.4-beta.rc1 -t polarlightning/lnd:0.18.4-beta.rc1 --push .
+$ docker buildx build --platform linux/amd64,linux/arm64 --build-arg LND_VERSION=<version> -t polarlightning/lnd:<version> --push .
 ```
 
 Replace `<version>` with the desired LND version (ex: `0.7.1-beta`)

--- a/docker/nodes.json
+++ b/docker/nodes.json
@@ -1,9 +1,10 @@
 {
-  "version": 66,
+  "version": 67,
   "images": {
     "LND": {
-      "latest": "0.18.4-beta.rc1",
+      "latest": "0.18.4-beta.rc2",
       "versions": [
+        "0.18.4-beta.rc2",
         "0.18.4-beta.rc1",
         "0.18.3-beta",
         "0.18.2-beta",
@@ -14,7 +15,8 @@
         "0.15.5-beta"
       ],
       "compatibility": {
-        "0.18.4-beta.rc1": "27.0",
+        "0.18.4-beta.rc2": "28.0",
+        "0.18.4-beta.rc1": "28.0",
         "0.18.3-beta": "27.0",
         "0.18.2-beta": "27.0",
         "0.18.1-beta": "27.0",
@@ -25,15 +27,15 @@
       }
     },
     "c-lightning": {
-      "latest": "24.08.1",
-      "versions": ["24.08.1", "24.08", "24.05", "24.02.2", "23.11.2"]
+      "latest": "24.11",
+      "versions": ["24.11", "24.08.1", "24.08", "24.05", "24.02.2", "23.11.2"]
     },
     "eclair": {
       "latest": "0.10.0",
       "versions": ["0.10.0", "0.9.0", "0.8.0", "0.7.0", "0.6.2", "0.5.0"]
     },
     "bitcoind": {
-      "latest": "27.0",
+      "latest": "28.0",
       "versions": ["28.0", "27.0", "26.0", "25.0", "24.0", "23.0", "22.0", "0.21.1"]
     },
     "btcd": {
@@ -41,8 +43,9 @@
       "versions": []
     },
     "tapd": {
-      "latest": "0.5.0-rc1",
+      "latest": "0.5.0-rc2",
       "versions": [
+        "0.5.0-rc2",
         "0.5.0-rc1",
         "0.4.1-alpha",
         "0.4.0-alpha",
@@ -50,6 +53,7 @@
         "0.3.2-alpha"
       ],
       "compatibility": {
+        "0.5.0-rc2": "0.18.4-beta.rc2",
         "0.5.0-rc1": "0.18.4-beta.rc1",
         "0.4.1-alpha": "0.18.0-beta",
         "0.4.0-alpha": "0.18.0-beta",
@@ -58,10 +62,11 @@
       }
     },
     "litd": {
-      "latest": "0.14.0-alpha.rc1",
-      "versions": ["0.14.0-alpha.rc1"],
+      "latest": "0.14.0-alpha.rc2",
+      "versions": ["0.14.0-alpha.rc2", "0.14.0-alpha.rc1"],
       "compatibility": {
-        "0.14.0-alpha.rc1": "27.0"
+        "0.14.0-alpha.rc2": "28.0",
+        "0.14.0-alpha.rc1": "28.0"
       }
     }
   }

--- a/src/store/models/designer.spec.ts
+++ b/src/store/models/designer.spec.ts
@@ -627,7 +627,7 @@ describe('Designer model', () => {
             expect.objectContaining({
               message: 'Failed to add node',
               error: new Error(
-                'This network does not contain a LND v0.18.4-beta.rc1 (or higher) ' +
+                'This network does not contain a LND v0.18.4-beta.rc2 (or higher) ' +
                   `node which is required for tapd v${tapdLatest}`,
               ),
             }),

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -379,11 +379,19 @@ export const defaultRepoState: DockerRepoState = {
       versions: [],
     },
     tapd: {
-      latest: '0.5.0-rc1',
-      versions: ['0.5.0-rc1', '0.4.1-alpha', '0.4.0-alpha', '0.3.3-alpha', '0.3.2-alpha'],
+      latest: '0.5.0-rc2',
+      versions: [
+        '0.5.0-rc2',
+        '0.5.0-rc1',
+        '0.4.1-alpha',
+        '0.4.0-alpha',
+        '0.3.3-alpha',
+        '0.3.2-alpha',
+      ],
       // Not all tapd versions are compatible with all LND versions.
       // This mapping specifies the minimum compatible LND for each tapd version
       compatibility: {
+        '0.5.0-rc2': '0.18.4-beta.rc2',
         '0.5.0-rc1': '0.18.4-beta.rc1',
         '0.4.1-alpha': '0.18.0-beta',
         '0.4.0-alpha': '0.18.0-beta',
@@ -395,7 +403,7 @@ export const defaultRepoState: DockerRepoState = {
       latest: '0.14.0-alpha.rc1',
       versions: ['0.14.0-alpha.rc1'],
       compatibility: {
-        '0.14.0-alpha.rc1': '27.0',
+        '0.14.0-alpha.rc1': '28.0',
       },
     },
   },

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -363,8 +363,8 @@ export const defaultRepoState: DockerRepoState = {
       },
     },
     'c-lightning': {
-      latest: '24.08.1',
-      versions: ['24.08.1', '24.08', '24.05', '24.02.2', '23.11.2'],
+      latest: '24.11',
+      versions: ['24.11', '24.08.1', '24.08', '24.05', '24.02.2', '23.11.2'],
     },
     eclair: {
       latest: '0.10.0',

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -336,8 +336,9 @@ export const defaultRepoState: DockerRepoState = {
   version: 66,
   images: {
     LND: {
-      latest: '0.18.4-beta.rc1',
+      latest: '0.18.4-beta.rc2',
       versions: [
+        '0.18.4-beta.rc2',
         '0.18.4-beta.rc1',
         '0.18.3-beta',
         '0.18.2-beta',
@@ -350,7 +351,8 @@ export const defaultRepoState: DockerRepoState = {
       // not all LND versions are compatible with all bitcoind versions.
       // this mapping specifies the highest compatible bitcoind for each LND version
       compatibility: {
-        '0.18.4-beta.rc1': '27.0',
+        '0.18.4-beta.rc2': '28.0',
+        '0.18.4-beta.rc1': '28.0',
         '0.18.3-beta': '27.0',
         '0.18.2-beta': '27.0',
         '0.18.1-beta': '27.0',
@@ -369,7 +371,7 @@ export const defaultRepoState: DockerRepoState = {
       versions: ['0.10.0', '0.9.0', '0.8.0', '0.7.0', '0.6.2', '0.5.0'],
     },
     bitcoind: {
-      latest: '27.0',
+      latest: '28.0',
       versions: ['28.0', '27.0', '26.0', '25.0', '24.0', '23.0', '22.0', '0.21.1'],
     },
     btcd: {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -333,7 +333,7 @@ export const REPO_STATE_URL =
  * are pushed to Docker Hub, this list should be updated along with the /docker/nodes.json file.
  */
 export const defaultRepoState: DockerRepoState = {
-  version: 66,
+  version: 67,
   images: {
     LND: {
       latest: '0.18.4-beta.rc2',
@@ -400,9 +400,10 @@ export const defaultRepoState: DockerRepoState = {
       },
     },
     litd: {
-      latest: '0.14.0-alpha.rc1',
-      versions: ['0.14.0-alpha.rc1'],
+      latest: '0.14.0-alpha.rc2',
+      versions: ['0.14.0-alpha.rc2', '0.14.0-alpha.rc1'],
       compatibility: {
+        '0.14.0-alpha.rc2': '28.0',
         '0.14.0-alpha.rc1': '28.0',
       },
     },

--- a/src/utils/network.spec.ts
+++ b/src/utils/network.spec.ts
@@ -12,6 +12,7 @@ import {
 import { Network } from 'types';
 import { defaultRepoState } from './constants';
 import {
+  createBitcoindNetworkNode,
   createCLightningNetworkNode,
   createLitdNetworkNode,
   createLndNetworkNode,
@@ -324,7 +325,7 @@ describe('Network Utils', () => {
     it('should add a tap node linked to the exact minimum LND version', async () => {
       const lnd = createLndNetworkNode(
         network,
-        '0.18.4-beta.rc1',
+        '0.18.4-beta.rc2',
         defaultRepoState.images.LND.compatibility,
         { image: '', command: '' },
         Status.Stopped,
@@ -343,6 +344,13 @@ describe('Network Utils', () => {
     });
 
     it('should fail to create a tap node without a compatible LND version', async () => {
+      const btc = createBitcoindNetworkNode(
+        network,
+        '27.0',
+        { image: '', command: '' },
+        Status.Stopped,
+      );
+      network.nodes.bitcoin.push(btc);
       const lnd = createLndNetworkNode(
         network,
         '0.15.5-beta',

--- a/src/utils/tests/helpers.ts
+++ b/src/utils/tests/helpers.ts
@@ -62,8 +62,9 @@ export const testRepoState: DockerRepoState = {
   version: 50,
   images: {
     LND: {
-      latest: '0.18.4-beta.rc1',
+      latest: '0.18.4-beta.rc2',
       versions: [
+        '0.18.4-beta.rc2',
         '0.18.4-beta.rc1',
         '0.18.3-beta',
         '0.18.2-beta',
@@ -106,7 +107,8 @@ export const testRepoState: DockerRepoState = {
       // not all LND versions are compatible with all bitcoind versions.
       // this mapping specifies the highest compatible bitcoind for each LND version
       compatibility: {
-        '0.18.4-beta.rc1': '27.0',
+        '0.18.4-beta.rc2': '28.0',
+        '0.18.4-beta.rc1': '28.0',
         '0.18.3-beta': '27.0',
         '0.18.2-beta': '27.0',
         '0.18.1-beta': '27.0',
@@ -175,11 +177,19 @@ export const testRepoState: DockerRepoState = {
       versions: [],
     },
     tapd: {
-      latest: '0.5.0-rc1',
-      versions: ['0.5.0-rc1', '0.4.1-alpha', '0.4.0-alpha', '0.3.3-alpha', '0.3.2-alpha'],
+      latest: '0.5.0-rc2',
+      versions: [
+        '0.5.0-rc2',
+        '0.5.0-rc1',
+        '0.4.1-alpha',
+        '0.4.0-alpha',
+        '0.3.3-alpha',
+        '0.3.2-alpha',
+      ],
       // Not all tapd versions are compatible with all LND versions.
       // This mapping specifies the minimum compatible LND for each tapd version
       compatibility: {
+        '0.5.0-rc2': '0.18.4-beta.rc2',
         '0.5.0-rc1': '0.18.4-beta.rc1',
         '0.4.1-alpha': '0.18.0-beta',
         '0.4.0-alpha': '0.18.0-beta',
@@ -191,7 +201,7 @@ export const testRepoState: DockerRepoState = {
       latest: '0.14.0-alpha.rc1',
       versions: ['0.14.0-alpha.rc1'],
       compatibility: {
-        '0.14.0-alpha.rc1': '27.0',
+        '0.14.0-alpha.rc1': '28.0',
       },
     },
   },


### PR DESCRIPTION
### Description

Adds support for the following new node versions:
- LND v0.18.4-beta.rc2
- tapd v0.5.0-alpha.rc2
- litd v0.14.0-alpha.rc2
- Core Lightning v24.11

### Screenshots

![image](https://github.com/user-attachments/assets/bfd548e5-77bc-45cd-bbb1-282eb4e8a3bf)

