### PR TITLE
fix(PayInvoiceModal): fix incorrect sats value displayed for paid inv…

### DIFF
--- a/src/components/designer/lightning/actions/PayInvoiceModal.spec.tsx
+++ b/src/components/designer/lightning/actions/PayInvoiceModal.spec.tsx
@@ -106,8 +106,8 @@ describe('PayInvoiceModal', () => {
       });
     });
 
-    it('should pay invoice successfully', async () => {
-      const { getByText, getByLabelText, store } = await renderComponent();
+    it('should pay invoice successfully and show correctly formatted success message', async () => {
+      const { getByText, getByLabelText, store, findByText } = await renderComponent();
       fireEvent.change(getByLabelText('BOLT 11 Invoice'), { target: { value: 'lnbc1' } });
       fireEvent.click(getByText('Pay Invoice'));
       await waitFor(() => {
@@ -119,6 +119,8 @@ describe('PayInvoiceModal', () => {
         'lnbc1',
         undefined,
       );
+      const element = await findByText('Sent 1,000 sats from alice');
+      expect(element).toBeInTheDocument();
     });
 
     it('should display an error when paying the invoice fails', async () => {

--- a/src/components/designer/lightning/actions/PayInvoiceModal.tsx
+++ b/src/components/designer/lightning/actions/PayInvoiceModal.tsx
@@ -85,7 +85,7 @@ const PayInvoiceModal: React.FC<Props> = ({ network }) => {
       const nodeName = node.name;
       notify({
         message: l('successTitle'),
-        description: l('successDesc', { amount: format(amount), nodeName, assetName }),
+        description: l('successDesc', { amount, nodeName, assetName }),
       });
       await hidePayInvoice();
     } catch (error: any) {

--- a/src/lib/tap/tapd/tapdService.spec.ts
+++ b/src/lib/tap/tapd/tapdService.spec.ts
@@ -235,7 +235,7 @@ describe('TapdService', () => {
       },
       paymentResult: {
         paymentPreimage: Buffer.from('preimage'),
-        valueMsat: 100_000_000,
+        valueMsat: 1_000_000,
       },
     };
     tapdProxyClient.sendPayment = jest.fn().mockResolvedValue(res);

--- a/src/lib/tap/tapd/tapdService.ts
+++ b/src/lib/tap/tapd/tapdService.ts
@@ -186,7 +186,7 @@ class TapdService implements TapService {
     const pmt = res.paymentResult as LND.Payment;
     return {
       // convert from msat to asset units using the default oracle exchange rate
-      amount: parseInt(pmt.valueMsat) / 100_000,
+      amount: parseInt(pmt.valueMsat) / 1000,
       preimage: pmt.paymentPreimage.toString(),
       destination: '',
     };


### PR DESCRIPTION
Closes #1107

### Description
This PR fixes a bug where an incorrect sats value is displayed by the notification for paid invoices (PayInvoiceModal)

### Steps to Test

1. Ensure you have the most current version of the master branch.
2. Set up a network with multiple Lightning nodes.
3. Generate an invoice with one node and pay it using another.
4. Pay close attention to the success notification.

### Screenshots
<img width="450" alt="Screenshot 2025-01-20 at 6 49 12 PM" src="https://github.com/user-attachments/assets/304803f1-f1da-4d0d-be01-cb05f3dec462" />

