### PR TITLE
Add support for the latest lnd, tapd, and litd versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ With Polar you can:
 
 Supported Network Node Versions:
 
-- [LND](https://github.com/lightningnetwork/lnd) - v0.18.4, v0.18.3, v0.17.5, v0.16.4
+- [LND](https://github.com/lightningnetwork/lnd) - v0.18.5, v0.18.4, v0.18.3, v0.17.5, v0.16.4
 - [Core Lightning](https://github.com/ElementsProject/lightning) - v24.11, v24.08, v24.05
 - [Eclair](https://github.com/ACINQ/eclair/) - v0.11.0, v0.10.0, v0.9.0
 - [Bitcoin Core](https://github.com/bitcoin/bitcoin) - v28.0, v27.0, v26.0
-- [Taproot Assets](https://github.com/lightninglabs/taproot-assets) - v0.5.0, v0.4.1, v0.3.3
-- [Terminal](https://github.com/lightninglabs/lightning-terminal) - v0.14.0
+- [Taproot Assets](https://github.com/lightninglabs/taproot-assets) - v0.5.1, v0.5.0, v0.4.1, v0.3.3
+- [Terminal](https://github.com/lightninglabs/lightning-terminal) - v0.14.1, v0.14.0
 
 ## Dependencies
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -49,6 +49,7 @@ Replace `<version>` with the desired bitcoind version (ex: `0.18.1`)
 
 ### Tags
 
+- `0.18.5-beta` ([lnd/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/lnd/Dockerfile))
 - `0.18.4-beta` ([lnd/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/lnd/Dockerfile))
 - `0.18.3-beta` ([lnd/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/lnd/Dockerfile))
 - `0.18.2-beta` ([lnd/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/lnd/Dockerfile))

--- a/docker/README.md
+++ b/docker/README.md
@@ -189,6 +189,7 @@ Replace `<version>` with the desired Tap version (ex: `0.2.0-alpha`).
 
 ### Tags
 
+- `0.14.1-alpha` ([litd/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/litd/Dockerfile))
 - `0.14.0-alpha` ([litd/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/litd/Dockerfile))
 
 **Building the image**

--- a/docker/README.md
+++ b/docker/README.md
@@ -164,6 +164,7 @@ Replace `<version>` with the desired Eclair version (ex: `0.3.3`).
 
 ### Tags
 
+- `0.5.1-alpha` ([tap/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/tapd/Dockerfile))
 - `0.5.0-alpha` ([tap/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/tapd/Dockerfile))
 - `0.4.1-alpha` ([tap/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/tapd/Dockerfile))
 - `0.4.0-alpha` ([tap/Dockerfile](https://github.com/jamaljsr/polar/blob/master/docker/tapd/Dockerfile))

--- a/docker/nodes.json
+++ b/docker/nodes.json
@@ -1,9 +1,10 @@
 {
-  "version": 68,
+  "version": 69,
   "images": {
     "LND": {
-      "latest": "0.18.4-beta",
+      "latest": "0.18.5-beta",
       "versions": [
+        "0.18.5-beta",
         "0.18.4-beta",
         "0.18.3-beta",
         "0.18.2-beta",
@@ -13,6 +14,7 @@
         "0.16.4-beta"
       ],
       "compatibility": {
+        "0.18.5-beta": "28.0",
         "0.18.4-beta": "28.0",
         "0.18.3-beta": "27.0",
         "0.18.2-beta": "27.0",
@@ -39,18 +41,20 @@
       "versions": []
     },
     "tapd": {
-      "latest": "0.5.0-alpha",
-      "versions": ["0.5.0-alpha", "0.4.1-alpha", "0.3.3-alpha"],
+      "latest": "0.5.1-alpha",
+      "versions": ["0.5.1-alpha", "0.5.0-alpha", "0.4.1-alpha", "0.3.3-alpha"],
       "compatibility": {
+        "0.5.1-alpha": "0.18.5-beta",
         "0.5.0-alpha": "0.18.4-beta",
         "0.4.1-alpha": "0.18.0-beta",
         "0.3.3-alpha": "0.16.0-beta"
       }
     },
     "litd": {
-      "latest": "0.14.0-alpha",
-      "versions": ["0.14.0-alpha"],
+      "latest": "0.14.1-alpha",
+      "versions": ["0.14.1-alpha", "0.14.0-alpha"],
       "compatibility": {
+        "0.14.1-alpha": "28.0",
         "0.14.0-alpha": "28.0"
       }
     }

--- a/src/store/models/designer.spec.ts
+++ b/src/store/models/designer.spec.ts
@@ -9,12 +9,12 @@ import { defaultRepoState, LOADING_NODE_ID } from 'utils/constants';
 import * as files from 'utils/files';
 import { createBitcoindNetworkNode, createCLightningNetworkNode } from 'utils/network';
 import {
+  bitcoinServiceMock,
   getNetwork,
   injections,
   lightningServiceMock,
   testNodeDocker,
   testRepoState,
-  bitcoinServiceMock,
 } from 'utils/tests';
 import appModel from './app';
 import bitcoinModel from './bitcoin';
@@ -626,7 +626,7 @@ describe('Designer model', () => {
             expect.objectContaining({
               message: 'Failed to add node',
               error: new Error(
-                'This network does not contain a LND v0.18.4-beta (or higher) ' +
+                'This network does not contain a LND v0.18.5-beta (or higher) ' +
                   `node which is required for tapd v${tapdLatest}`,
               ),
             }),

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -377,11 +377,12 @@ export const defaultRepoState: DockerRepoState = {
       versions: [],
     },
     tapd: {
-      latest: '0.5.0-alpha',
-      versions: ['0.5.0-alpha', '0.4.1-alpha', '0.3.3-alpha'],
+      latest: '0.5.1-alpha',
+      versions: ['0.5.1-alpha', '0.5.0-alpha', '0.4.1-alpha', '0.3.3-alpha'],
       // Not all tapd versions are compatible with all LND versions.
       // This mapping specifies the minimum compatible LND for each tapd version
       compatibility: {
+        '0.5.1-alpha': '0.18.5-beta',
         '0.5.0-alpha': '0.18.4-beta',
         '0.4.1-alpha': '0.18.0-beta',
         '0.3.3-alpha': '0.16.0-beta',

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -389,9 +389,10 @@ export const defaultRepoState: DockerRepoState = {
       },
     },
     litd: {
-      latest: '0.14.0-alpha',
-      versions: ['0.14.0-alpha'],
+      latest: '0.14.1-alpha',
+      versions: ['0.14.1-alpha', '0.14.0-alpha'],
       compatibility: {
+        '0.14.1-alpha': '28.0',
         '0.14.0-alpha': '28.0',
       },
     },

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -336,8 +336,9 @@ export const defaultRepoState: DockerRepoState = {
   version: 68,
   images: {
     LND: {
-      latest: '0.18.4-beta',
+      latest: '0.18.5-beta',
       versions: [
+        '0.18.5-beta',
         '0.18.4-beta',
         '0.18.3-beta',
         '0.18.2-beta',
@@ -349,6 +350,7 @@ export const defaultRepoState: DockerRepoState = {
       // not all LND versions are compatible with all bitcoind versions.
       // this mapping specifies the highest compatible bitcoind for each LND version
       compatibility: {
+        '0.18.5-beta': '28.0',
         '0.18.4-beta': '28.0',
         '0.18.3-beta': '27.0',
         '0.18.2-beta': '27.0',

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -333,7 +333,7 @@ export const REPO_STATE_URL =
  * are pushed to Docker Hub, this list should be updated along with the /docker/nodes.json file.
  */
 export const defaultRepoState: DockerRepoState = {
-  version: 68,
+  version: 69,
   images: {
     LND: {
       latest: '0.18.5-beta',

--- a/src/utils/network.spec.ts
+++ b/src/utils/network.spec.ts
@@ -325,7 +325,7 @@ describe('Network Utils', () => {
     it('should add a tap node linked to the exact minimum LND version', async () => {
       const lnd = createLndNetworkNode(
         network,
-        '0.18.4-beta.rc2',
+        '0.18.5-beta',
         defaultRepoState.images.LND.compatibility,
         { image: '', command: '' },
         Status.Stopped,

--- a/src/utils/tests/helpers.ts
+++ b/src/utils/tests/helpers.ts
@@ -62,8 +62,9 @@ export const testRepoState: DockerRepoState = {
   version: 50,
   images: {
     LND: {
-      latest: '0.18.4-beta',
+      latest: '0.18.5-beta',
       versions: [
+        '0.18.5-beta',
         '0.18.4-beta',
         '0.18.3-beta',
         '0.18.2-beta',
@@ -106,6 +107,7 @@ export const testRepoState: DockerRepoState = {
       // not all LND versions are compatible with all bitcoind versions.
       // this mapping specifies the highest compatible bitcoind for each LND version
       compatibility: {
+        '0.18.5-beta': '28.0',
         '0.18.4-beta': '28.0',
         '0.18.3-beta': '27.0',
         '0.18.2-beta': '27.0',
@@ -175,8 +177,9 @@ export const testRepoState: DockerRepoState = {
       versions: [],
     },
     tapd: {
-      latest: '0.5.0-alpha',
+      latest: '0.5.1-alpha',
       versions: [
+        '0.5.1-alpha',
         '0.5.0-alpha',
         '0.4.1-alpha',
         '0.4.0-alpha',
@@ -186,6 +189,7 @@ export const testRepoState: DockerRepoState = {
       // Not all tapd versions are compatible with all LND versions.
       // This mapping specifies the minimum compatible LND for each tapd version
       compatibility: {
+        '0.5.1-alpha': '0.18.5-beta',
         '0.5.0-alpha': '0.18.4-beta',
         '0.4.1-alpha': '0.18.0-beta',
         '0.4.0-alpha': '0.18.0-beta',


### PR DESCRIPTION
Adds support for the latest lnd, tapd, and litd versions:
- `lnd` v0.18.5-beta
- `tapd` v0.5.1-alpha
- `litd` v0.14.1-alpha

![image](https://github.com/user-attachments/assets/9522ccd5-a3e7-47bf-bbec-532e78dfab75)
