### PR TITLE
style(detectdockermodal.spec.tsx): updates the Docker detection error…

### DIFF
--- a/src/components/home/DetectDockerModal.spec.tsx
+++ b/src/components/home/DetectDockerModal.spec.tsx
@@ -37,7 +37,9 @@ describe('DetectDockerModal component', () => {
 
   it('should display UI elements', () => {
     const { getByText, getAllByText } = renderComponent();
-    expect(getByText('Docker Not Detected')).toBeInTheDocument();
+    expect(
+      getByText('Docker not detected. Make sure Docker is both installed and running.'),
+    ).toBeInTheDocument();
     expect(getByText('Installed Docker Versions')).toBeInTheDocument();
     expect(getByText('Check Again')).toBeInTheDocument();
     expect(getAllByText('Not Found')).toHaveLength(2);
@@ -45,18 +47,24 @@ describe('DetectDockerModal component', () => {
 
   it('should not display modal if docker versions are set', () => {
     const { queryByText } = renderComponent('1.2.3', '4.5.6');
-    expect(queryByText('Docker Not Detected')).toBeNull();
+    expect(
+      queryByText('Docker not detected. Make sure Docker is both installed and running.'),
+    ).toBeNull();
   });
 
   it('should display modal if docker version is not set', () => {
     const { getByText } = renderComponent('', '1.2.3');
-    expect(getByText('Docker Not Detected')).toBeInTheDocument();
+    expect(
+      getByText('Docker not detected. Make sure Docker is both installed and running.'),
+    ).toBeInTheDocument();
     expect(getByText('1.2.3')).toBeInTheDocument();
   });
 
   it('should display modal if compose version is not set', () => {
     const { getByText } = renderComponent('1.2.3');
-    expect(getByText('Docker Not Detected')).toBeInTheDocument();
+    expect(
+      getByText('Docker not detected. Make sure Docker is both installed and running.'),
+    ).toBeInTheDocument();
     expect(getByText('1.2.3')).toBeInTheDocument();
   });
 

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -456,7 +456,7 @@
   "cmps.dockerLogs.ViewLogsButton.openMsg": "Opening logs...",
   "cmps.home.DetectDockerModal.dockerError": "Docker Error",
   "cmps.home.DetectDockerModal.notFound": "Not Found",
-  "cmps.home.DetectDockerModal.notDetected": "Docker Not Detected",
+  "cmps.home.DetectDockerModal.notDetected": "Docker not detected. Make sure Docker is both installed and running.",
   "cmps.home.DetectDockerModal.description": "To start a Lightning Network, you must have Docker and Docker Compose installed and running on this computer.",
   "cmps.home.DetectDockerModal.download": "Download",
   "cmps.home.DetectDockerModal.versionsTitle": "Installed Docker Versions",


### PR DESCRIPTION

Updates the Docker detection error message to be more specific and helpful by explicitly stating that Docker needs to be both installed and running

Closes #1210

### Description

Updates the Docker detection error message to be more specific and helpful by explicitly stating that Docker needs to be both installed and running.

Changes
Updated error message text in  src/i18n/locales/en-US.json
Updated corresponding test cases in  src/components/home/DetectDockerModal.spec.tsx

### Steps to Test

1. Ensure Docker is installed but not running If Docker is currently running, stop it

2. clone and run current branch/PR
3. Verify the new error message
4. Start Docker and check again

### Screenshots


![Screenshot from 2025-05-21 01-52-40](https://github.com/user-attachments/assets/8441d609-c25e-4e94-b02f-9265cc924455)

