### PR TITLE
docs(docker): fix awk compatibility in setup instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ first build the headless image, then run:
 
 ```sh
 cd .devcontainer/
-docker_gid_host=$(getent group docker | awk --field-separator : '{print $3}')
+docker_gid_host=$(getent group docker | awk -F: '{print $3}')
 docker image build --build-arg="DOCKER_GID=${docker_gid_host}" --tag polardev:ui .
 ```
 


### PR DESCRIPTION
Closes #1221 

### Description

Fixed cross-platform compatibility issue in CONTRIBUTING.md Docker setup instructions. The documentation used GNU-specific `awk --field-separator` syntax that fails on systems using `mawk` (like Ubuntu by default).

**Technical change:** Replaced `awk --field-separator :` with the portable `awk -F:` syntax that works across all awk implementations (`mawk`, `gawk`, BSD awk, etc.).

### Steps to Test

1. Use a system with `mawk` (like Ubuntu)
2. Follow the Docker approach section in CONTRIBUTING.md
3. Run the updated command: `docker_gid_host=$(getent group docker | awk -F: '{print $3}')`
4. Verify it successfully extracts the Docker group GID without errors

### Screenshots

**Before (error on Ubuntu):**
```bash
$ docker_gid_host=$(getent group docker | awk --field-separator : '{print $3}')
awk: not an option: --field-separator
```

**After (works on all systems):**
```bash
$ docker_gid_host=$(getent group docker | awk -F: '{print $3}')
$ echo $docker_gid_host
998
```