### PR TITLE
fix: use correct ports for the litd GRPC and REST endpoints

### DIFF
--- a/src/components/designer/lightning/ConnectTab.tsx
+++ b/src/components/designer/lightning/ConnectTab.tsx
@@ -135,9 +135,9 @@ const ConnectTab: React.FC<Props> = ({ node }) => {
       } else if (node.implementation === 'litd') {
         const litd = node as LitdNode;
         return {
-          restUrl: `https://127.0.0.1:${litd.ports.web}`,
+          restUrl: `https://127.0.0.1:${litd.ports.rest}`,
           restDocsUrl: 'https://lightning.engineering/api-docs/api/lit/',
-          grpcUrl: `127.0.0.1:${litd.ports.web}`,
+          grpcUrl: `127.0.0.1:${litd.ports.web}`, // external grpc is on web port
           grpcDocsUrl: 'https://lightning.engineering/api-docs/api/lit/',
           webUrl: `https://127.0.0.1:${litd.ports.web}`,
           credentials: {

--- a/src/components/designer/lightning/LightningDetails.spec.tsx
+++ b/src/components/designer/lightning/LightningDetails.spec.tsx
@@ -466,6 +466,13 @@ describe('LightningDetails', () => {
         expect(getByText('500')).toBeInTheDocument();
       });
 
+      it('should display the REST Host', async () => {
+        const { getByText, findByText } = renderComponent(Status.Started);
+        fireEvent.click(await findByText('Connect'));
+        expect(getByText('REST Host')).toBeInTheDocument();
+        expect(getByText('https://127.0.0.1:8385')).toBeInTheDocument();
+      });
+
       it('should display the GRPC Host', async () => {
         const { getByText, findByText } = renderComponent(Status.Started);
         fireEvent.click(await findByText('Connect'));


### PR DESCRIPTION
### Description

When using a lightning-terminal node, the `Connect` tab wrongly shows the web endpoint's port for the GRPC and REST endpoints. Those endpoints have different ports.

### Steps to Test

- Add a litd node to a network.
- Click on the node and open the `Connect` tab in the right sidebar
- The GRPC and REST endpoints should have different ports from the web endpoint