### PR TITLE
ci: use macos-15-intel github CI image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         node_version: [20.x]
-        os: [ubuntu-latest, windows-latest, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-15-intel]
 
     steps:
       - name: ubuntu file watcher tweak


### PR DESCRIPTION
### Description

Github will be retiring the `macos-13` runner image on Dec 4. This PR updates our workflow to use `macos-15-intel`.

### Screenshots

<img width="961" height="1336" alt="image" src="https://github.com/user-attachments/assets/bb8c2eca-31e6-4338-bfdb-9e7d6b004070" />

