### PR TITLE
Allow tapd REST endpoint to be called from within the Docker network

### DIFF
--- a/docker/litd/docker-entrypoint.sh
+++ b/docker/litd/docker-entrypoint.sh
@@ -17,7 +17,8 @@ fi
 if [ $(echo "$1" | cut -c1) = "-" ]; then
   echo "$0: assuming arguments for litd"
 
-  set -- litd "$@"
+  CONTAINER_IP=$(hostname -i)
+  set -- litd --lnd-tlsextraip=$CONTAINER_IP --lnd-tlsextradomain=$(hostname) "$@"
 fi
 
 if [ "$1" = "litd" ] || [ "$1" = "litcli" ]; then


### PR DESCRIPTION
### Description

I've been setting up additional services inside the Polar Docker network and sometimes they need to call the nodes' API.

The certificate generated for tapd has an altname configured for the Docker host's IP address, but not for the docker container itself.

This PR fixes that.

### Steps to Test

1. Create a tapd node in Polar
2. Make an HTTP REST call from another Docker container
3. With this PR it should work, without it you should get a TLS certificate error.

@jamaljsr If you agree with this change, we should probably do the same for LND as well (and not just LITD).

