### PR TITLE
fix(bitcoindservice.ts and bitcoindservice.spec.ts): setting up defau…

### DIFF
--- a/src/lib/bitcoin/bitcoind/bitcoindService.spec.ts
+++ b/src/lib/bitcoin/bitcoind/bitcoindService.spec.ts
@@ -32,6 +32,18 @@ describe('BitcoindService', () => {
     mockProto.generateToAddress = jest.fn().mockResolvedValue(['blockhash1']);
   });
 
+  // Adding Test case for selecting default wallet and not create a new one
+  it('should initialize the client with an explicit empty wallet path', () => {
+    bitcoindService.createClient(node);
+    // getInst() retrieves the first instance of BitcoinCore created
+    // We check if it was initialized with the 'wallet' property set to ''
+    expect(mockBitcoin).toHaveBeenCalledWith(
+      expect.objectContaining({
+        wallet: '',
+      }),
+    );
+  });
+
   it('should create a default wallet', async () => {
     mockProto.listWallets = jest.fn().mockResolvedValue([]);
     await bitcoindService.createDefaultWallet(node);

--- a/src/lib/bitcoin/bitcoind/bitcoindService.ts
+++ b/src/lib/bitcoin/bitcoind/bitcoindService.ts
@@ -17,6 +17,8 @@ class BitcoindService implements BitcoinService {
       host: `http://127.0.0.1:${node.ports.rpc}`,
       username: bitcoinCredentials.user,
       password: bitcoinCredentials.pass,
+      // default wallet to resolve multi-wallet conflict
+      wallet: '',
       logger: this.log(),
       // use a long timeout due to the time it takes to mine a lot of blocks
       timeout: 5 * 60 * 1000,


### PR DESCRIPTION
Closes #1096

## Description

### The Problem
By default, when multiple wallets are loaded in a Bitcoin Core node, RPC calls require an explicit wallet context. Polar was previously making calls to the base RPC endpoint. When a user connected an external tool (like Sparrow Wallet) that created additional wallets, Bitcoin Core would return an error:

**The Fix**
I updated the _BitcoindService_ to ensure all RPC interactions are explicitly directed to the default Polar wallet, even if other wallets are present on the node.

**Explicit Wallet Targeting:** Modified the RPC client configuration to append wallet/ to the base URL path.

**Default Wallet Fallback:** Ensured that commands are executed against the default wallet ("" or the primary loaded wallet) by utilizing the -rpcwallet equivalent in the service layer.

**Technical Changes**
src/lib/bitcoin/bitcoindService.ts: Updated the RPC request logic to include the wallet name in the request path.


### Verification Results
<-- 
Manual Testing: Verified that Polar remains connected and functional even after creating multiple wallets via bitcoin-cli and Sparrow Wallet on a Regtest node. 
-->

**Linting:** yarn lint:all passes successfully.

**Tests:** All unit tests pass.

## Steps to Test

1. Download Sparrow Wallet
2. Open Sparrow Wallet in regtest mode by opening it using "Sparrow.exe -n regtest" command
3. Generate keys and connect wallet to Polar by selecting "Bitcoin Core" as Polar acts as a Core Network
4. Provide values of credentials from the Polar Network and connect it.
5. The issue is resolved.

## Screenshots
<img width="1908" height="1004" alt="image" src="https://github.com/user-attachments/assets/2f0e7c24-e4ec-4a75-9db3-a505b4d6b7a3" />
<img width="1460" height="870" alt="Screenshot 2026-01-27 205714" src="https://github.com/user-attachments/assets/d8197ba4-0f43-425f-842c-4f3144d4a344" />