### PR TITLE
build(eclair): add noble-based image for Eclair nodes

### DIFF
--- a/docker/eclair/Dockerfile
+++ b/docker/eclair/Dockerfile
@@ -1,7 +1,7 @@
 #########################
 # Original Source: https://github.com/ACINQ/eclair/blob/v0.12.0/Dockerfile
 #########################
-FROM eclipse-temurin:25.0.1_8-jdk-alpine as BUILD
+FROM eclipse-temurin:25.0.2_10-jdk-noble as BUILD
 
 # Let's fetch eclair dependencies, so that Docker can cache them
 # This way we won't have to fetch dependencies again if only the source code changes
@@ -28,7 +28,7 @@ FROM eclipse-temurin:25.0.1_8-jdk-alpine as BUILD
 
 #################### Polar Modification
 # Pull source code from github instead of a local repo
-RUN apk add git
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/repo
 ARG ECLAIR_VERSION
@@ -55,11 +55,11 @@ RUN cp -R -f /usr/repo/* .
 RUN ./mvnw package -pl eclair-node -am -DskipTests -Dgit.commit.id=notag -Dgit.commit.id.abbrev=notag -o
 # It might be good idea to run the tests here, so that the docker build fail if the code is bugged
 
-FROM eclipse-temurin:25.0.1_8-jre-alpine
+FROM eclipse-temurin:25.0.2_10-jre-noble
 WORKDIR /app
 
 # install jq for eclair-cli
-RUN apk add bash jq curl unzip su-exec
+RUN apt-get update && apt-get install -y bash jq curl unzip gosu && rm -rf /var/lib/apt/lists/*
 
 # copy and install eclair-cli executable
 COPY --from=BUILD /usr/src/eclair-core/eclair-cli .
@@ -81,10 +81,10 @@ RUN chmod -R a+x eclair-node/*
 RUN ls -al eclair-node/bin
 
 RUN curl -SLO https://raw.githubusercontent.com/ACINQ/eclair/master/contrib/eclair-cli.bash-completion \
-  && mkdir /etc/bash_completion.d \
+  && mkdir -p /etc/bash_completion.d \
   && mv eclair-cli.bash-completion /etc/bash_completion.d/ \
   && curl -SLO https://raw.githubusercontent.com/scop/bash-completion/master/bash_completion \
-  && mkdir /usr/share/bash-completion/ \
+  && mkdir -p /usr/share/bash-completion/ \
   && mv bash_completion /usr/share/bash-completion/
 
 COPY docker-entrypoint.sh /entrypoint.sh

--- a/docker/eclair/docker-entrypoint.sh
+++ b/docker/eclair/docker-entrypoint.sh
@@ -12,8 +12,8 @@ if ! id eclair > /dev/null 2>&1; then
   GROUPID=${GROUPID:-1000}
 
   echo "adding user eclair ($USERID:$GROUPID)"
-  addgroup -g $GROUPID eclair
-  adduser -D -u $USERID -G eclair eclair
+  groupadd -f -g $GROUPID eclair
+  useradd -r -u $USERID -g $GROUPID -o eclair
   # ensure correct ownership of user home dir
   mkdir -p /home/eclair
   chown -R $USERID:$GROUPID /home/eclair
@@ -38,7 +38,7 @@ if [ "$1" = "polar-eclair" ]; then
 
   echo "Running as eclair user:"
   echo "bash eclair-node/bin/eclair-node.sh $JAVA_OPTS"
-  exec su-exec eclair bash eclair-node/bin/eclair-node.sh $JAVA_OPTS
+  exec gosu eclair bash eclair-node/bin/eclair-node.sh $JAVA_OPTS
 fi
 
 echo "Running: $@"


### PR DESCRIPTION
Closes #1212 

### Description
This PR fixes a bug where eclair crashes when trying to open channels with the v0.12.0 & v0.13.1 Docker images. This is with eclair <-> eclair and eclair<->lnd channels. Uses; 
- eclipse-temurin:25.0.2_10-jdk-noble as build image
- eclipse-temurin:25.0.2_10-jre-noble as runtime image

### Steps to Test

1. Create nextwork eclair and lnd nodes
2. Create eclair <-> eclair and eclair<->lnd channels

### Screenshots

<img width="1272" height="905" alt="Screenshot from 2026-03-01 21-02-46" src="https://github.com/user-attachments/assets/a7098fc4-a822-44c5-9476-a72333f9b9ec" />
