### PR TITLE
feat: prevent lightning invoice payments when no funds exist

### DIFF
--- a/src/components/designer/lightning/actions/PayInvoiceModal.spec.tsx
+++ b/src/components/designer/lightning/actions/PayInvoiceModal.spec.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { act, fireEvent, waitFor } from '@testing-library/react';
 import { Status } from 'shared/types';
+
 import { LightningNodeChannelAsset } from 'lib/lightning/types';
 import { Network } from 'types';
 import { initChartFromNetwork } from 'utils/chart';
@@ -8,6 +9,7 @@ import { defaultRepoState } from 'utils/constants';
 import { createNetwork, mapToTapd } from 'utils/network';
 import {
   defaultStateChannel,
+  defaultStateInfo,
   getNetwork,
   lightningServiceMock,
   renderWithProviders,
@@ -23,6 +25,18 @@ describe('PayInvoiceModal', () => {
 
   beforeEach(() => {
     network = getNetwork(1, 'test network');
+    lightningServiceMock.getBalances.mockResolvedValue({
+      confirmed: '1000',
+      total: '1000',
+      unconfirmed: '0',
+    });
+    lightningServiceMock.getChannels.mockResolvedValue([
+      defaultStateChannel({
+        uniqueId: 'channel-1',
+        localBalance: '1000',
+        remoteBalance: '0',
+      }),
+    ]);
   });
 
   const renderComponent = async (nodeName = 'alice') => {
@@ -46,6 +60,9 @@ describe('PayInvoiceModal', () => {
     const cmp = <PayInvoiceModal network={network} />;
     const result = renderWithProviders(cmp, { initialState });
     unmount = result.unmount;
+    if (nodeName !== 'invalid') {
+      await result.findByLabelText('BOLT 11 Invoice');
+    }
     return result;
   };
 
@@ -130,6 +147,92 @@ describe('PayInvoiceModal', () => {
       fireEvent.click(getByText('Pay Invoice'));
       expect(await findByText('Unable to pay the Invoice')).toBeInTheDocument();
       expect(await findByText('error-msg')).toBeInTheDocument();
+    });
+
+    it('should disable the pay button and display a warning when the node has no funds available to pay the invoice', async () => {
+      lightningServiceMock.getBalances.mockResolvedValue({
+        confirmed: '0',
+        total: '0',
+        unconfirmed: '0',
+      });
+      lightningServiceMock.getChannels.mockResolvedValue([
+        defaultStateChannel({
+          uniqueId: 'channel-1',
+          localBalance: '0',
+          remoteBalance: '1000',
+        }),
+      ]);
+      const { findByText, getByText } = await renderComponent();
+      expect(getByText('Pay Invoice').closest('button')).toBeDisabled();
+      expect(
+        await findByText(
+          'Node has no funds available to pay invoices. Fund the node or open a channel with outbound liquidity and try again.',
+        ),
+      ).toBeInTheDocument();
+      expect(lightningServiceMock.payInvoice).not.toHaveBeenCalled();
+    });
+
+    it('should enable the pay button when the only funded channel was opened by a peer', async () => {
+      // Regression test: a channel opened by a peer only appears in that peer's
+      // channel list (as remoteBalance), so the selected node's own getChannels
+      // is empty. Its outbound liquidity must still be recognized.
+      lightningServiceMock.getInfo.mockImplementation(async n =>
+        defaultStateInfo({ pubkey: `${n.name}-pubkey` }),
+      );
+      lightningServiceMock.getChannels.mockImplementation(async n =>
+        n.name === 'bob'
+          ? [
+              defaultStateChannel({
+                uniqueId: 'channel-1',
+                pubkey: 'alice-pubkey', // bob opened this channel to alice
+                localBalance: '1000',
+                remoteBalance: '500',
+              }),
+            ]
+          : [],
+      );
+      const { getByText, queryByText } = await renderComponent('alice');
+      expect(getByText('Pay Invoice').closest('button')).not.toBeDisabled();
+      expect(
+        queryByText(
+          'Node has no funds available to pay invoices. Fund the node or open a channel with outbound liquidity and try again.',
+        ),
+      ).not.toBeInTheDocument();
+    });
+
+    it('should disable the pay button if the only channels with funds are pending, closed, or have invalid balance', async () => {
+      lightningServiceMock.getBalances.mockResolvedValue({
+        confirmed: '0',
+        total: '0',
+        unconfirmed: '0',
+      });
+      lightningServiceMock.getChannels.mockResolvedValue([
+        defaultStateChannel({
+          uniqueId: 'channel-1',
+          localBalance: '1000',
+          remoteBalance: '0',
+          pending: true,
+        }),
+        defaultStateChannel({
+          uniqueId: 'channel-2',
+          localBalance: '1000',
+          remoteBalance: '0',
+          status: 'Closed',
+        }),
+        defaultStateChannel({
+          uniqueId: 'channel-3',
+          localBalance: 'not-a-number',
+          remoteBalance: '0',
+        }),
+      ]);
+      const { findByText, getByText } = await renderComponent();
+      expect(getByText('Pay Invoice').closest('button')).toBeDisabled();
+      expect(
+        await findByText(
+          'Node has no funds available to pay invoices. Fund the node or open a channel with outbound liquidity and try again.',
+        ),
+      ).toBeInTheDocument();
+      expect(lightningServiceMock.payInvoice).not.toHaveBeenCalled();
     });
   });
 

--- a/src/components/designer/lightning/actions/PayInvoiceModal.tsx
+++ b/src/components/designer/lightning/actions/PayInvoiceModal.tsx
@@ -1,18 +1,19 @@
+import styled from '@emotion/styled';
+import { Alert, Form, Input, Modal, Select } from 'antd';
+import { Loader } from 'components/common';
+import AssetAmount from 'components/common/AssetAmount';
+import LightningNodeSelect from 'components/common/form/LightningNodeSelect';
+import { usePrefixedTranslation } from 'hooks';
+import { LightningNodeChannelAsset } from 'lib/lightning/types';
+
 import React, { useMemo } from 'react';
 import { useAsync, useAsyncCallback } from 'react-async-hook';
-import styled from '@emotion/styled';
-import { Form, Input, Modal, Select } from 'antd';
-import { usePrefixedTranslation } from 'hooks';
 import { LitdNode } from 'shared/types';
-import { LightningNodeChannelAsset } from 'lib/lightning/types';
 import { useStoreActions, useStoreState } from 'store';
 import { Network } from 'types';
 import { mapToTapd } from 'utils/network';
 import { ellipseInner } from 'utils/strings';
 import { format } from 'utils/units';
-import { Loader } from 'components/common';
-import AssetAmount from 'components/common/AssetAmount';
-import LightningNodeSelect from 'components/common/form/LightningNodeSelect';
 
 const Styled = {
   AssetOption: styled.div`
@@ -38,6 +39,7 @@ interface Props {
 const PayInvoiceModal: React.FC<Props> = ({ network }) => {
   const { l } = usePrefixedTranslation('cmps.designer.lightning.actions.PayInvoiceModal');
   const { visible, nodeName } = useStoreState(s => s.modals.payInvoice);
+  const { nodes } = useStoreState(s => s.lightning);
   const { getAssetsInChannels } = useStoreState(s => s.lit);
   const { formatAssetAmount } = useStoreState(s => s.tap);
   const { hidePayInvoice } = useStoreActions(s => s.modals);
@@ -48,14 +50,29 @@ const PayInvoiceModal: React.FC<Props> = ({ network }) => {
 
   const [form] = Form.useForm();
   const assetId = Form.useWatch<string>('assetId', form) || 'sats';
-  const selectedName = Form.useWatch<string>('node', form) || '';
+  const selectedName = Form.useWatch<string>('node', form) || nodeName || '';
+
+  const selectedNode = useMemo(
+    () => network.nodes.lightning.find(n => n.name === selectedName),
+    [network.nodes.lightning, selectedName],
+  );
 
   const getAssetsAsync = useAsync(async () => {
     if (!visible) return;
+
+    if (selectedNode) {
+      await getInfo(selectedNode).catch(() => undefined);
+      // Fetch every node's channels so the selected node's full
+      // outbound liquidity, including peer-opened channels, can be totaled.
+      await Promise.all(
+        network.nodes.lightning.map(node => getChannels(node).catch(() => undefined)),
+      );
+    }
+
+    // Fetch litd-specific asset data
     const litNodes = network.nodes.lightning.filter(n => n.implementation === 'litd');
     for (const node of litNodes) {
-      await getInfo(node);
-      await getChannels(node);
+      if (node.name !== selectedNode?.name) await getInfo(node).catch(() => undefined);
       await getAssetRoots(mapToTapd(node));
     }
   }, [network.nodes, visible]);
@@ -63,6 +80,31 @@ const PayInvoiceModal: React.FC<Props> = ({ network }) => {
   const assets = useMemo(() => {
     return getAssetsInChannels({ nodeName: selectedName }).map(a => a.asset);
   }, [getAssetsInChannels, selectedName]);
+  const outboundLiquidity = useMemo(() => {
+    // The selected node's spendable balance in a channel is `localBalance` when
+    // it opened the channel, or `remoteBalance` when a peer opened it (in which
+    // case the channel only appears in the peer's channel list).
+    const selfPubkey = nodes[selectedName]?.info?.pubkey;
+    return network.nodes.lightning.reduce((total, node) => {
+      const channels = nodes[node.name]?.channels || [];
+      return channels.reduce((sum, channel) => {
+        if (channel.pending || channel.status !== 'Open') return sum;
+        let balance = 0;
+        if (node.name === selectedName) {
+          balance = parseInt(channel.localBalance || '0', 10);
+        } else if (selfPubkey && channel.pubkey === selfPubkey) {
+          balance = parseInt(channel.remoteBalance || '0', 10);
+        }
+        return sum + (Number.isFinite(balance) ? balance : 0);
+      }, total);
+    }, 0);
+  }, [nodes, network.nodes.lightning, selectedName]);
+  const hasNoPaymentFunds =
+    assetId === 'sats' &&
+    !!selectedNode &&
+    !getAssetsAsync.loading &&
+    nodes[selectedName]?.channels !== undefined &&
+    outboundLiquidity <= 0;
 
   const payAsync = useAsyncCallback(async (values: FormValues) => {
     try {
@@ -104,6 +146,7 @@ const PayInvoiceModal: React.FC<Props> = ({ network }) => {
       okText={l('okBtn')}
       okButtonProps={{
         loading: payAsync.loading,
+        disabled: payAsync.loading || hasNoPaymentFunds,
       }}
       onOk={form.submit}
     >
@@ -119,6 +162,7 @@ const PayInvoiceModal: React.FC<Props> = ({ network }) => {
           onFinish={payAsync.execute}
           disabled={payAsync.loading}
         >
+          {hasNoPaymentFunds && <Alert type="warning" message={l('noFundsError')} />}
           <LightningNodeSelect
             network={network}
             name="node"

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -281,6 +281,7 @@
   "cmps.designer.lightning.actions.PayInvoiceModal.submitError": "Unable to pay the Invoice",
   "cmps.designer.lightning.actions.PayInvoiceModal.successTitle": "Successfully paid the Invoice",
   "cmps.designer.lightning.actions.PayInvoiceModal.successDesc": "Sent {{amount}} {{assetName}} from {{nodeName}}",
+  "cmps.designer.lightning.actions.PayInvoiceModal.noFundsError": "Node has no funds available to pay invoices. Fund the node or open a channel with outbound liquidity and try again.",
   "cmps.designer.lightning.actions.PaymentButtons.paymentsTitle": "Payments",
   "cmps.designer.lightning.actions.PaymentButtons.payInvoice": "Pay Invoice",
   "cmps.designer.lightning.actions.PaymentButtons.createInvoice": "Create Invoice",


### PR DESCRIPTION
## Prevent paying invoices from nodes that have neither wallet funds nor wallet liquidity.

re #1358

### Description

This PR addresses a usability issue where the application previously allowed users to attempt paying Lightning invoices from nodes with 0 sats and no outbound liquidity, resulting in a "Sent NaN sats from ..." toast message. 

**Changes included:**
- **Pre-Payment Validation:** Added logic in the Lightning model (`lightning.ts`) to verify if a node has either a confirmed wallet balance or available outbound channel liquidity before attempting to pay an invoice.
- **Improved UI Feedback:** Updated the **Pay Invoice Modal** (`PayInvoiceModal.tsx`) to disable payment execution and display a helpful warning alert when the selected node lacks funds, guiding the user to either fund the node or open a channel with outbound liquidity first.
- **Helper Utilities:** Extracted validation logic for inbound/outbound liquidity into cleanly separated utility functions (`utils.ts`).
- **Unit Tests:** Added comprehensive test coverage in `lightning.spec.ts` to ensure the payment rejection works securely when liquidity is missing, and processes successfully when available.

### Steps to Test

1. Create a network with default settings.
2. Create an invoice with a node, and try paying with another, unfunded node.

### Screenshots

https://github.com/user-attachments/assets/8040eb1f-2ae4-47ce-940c-61f2eb4eb34d


