### PR TITLE
fix: delete cln node host directory on removal

### DIFF
--- a/src/store/models/network.ts
+++ b/src/store/models/network.ts
@@ -1,6 +1,5 @@
 import { ipcRenderer, remote, SaveDialogOptions } from 'electron';
 import { info } from 'electron-log';
-import { join } from 'path';
 import { push } from 'connected-react-router';
 import { Action, action, Computed, computed, Thunk, thunk } from 'easy-peasy';
 import {
@@ -14,9 +13,10 @@ import {
   TapdNode,
   TapNode,
 } from 'shared/types';
-import { AutoMineMode, CustomImage, Network, StoreInjections, Simulation } from 'types';
+import { AutoMineMode, CustomImage, Network, Simulation, StoreInjections } from 'types';
 import { delay } from 'utils/async';
 import { initChartFromNetwork } from 'utils/chart';
+import { nodePath } from 'utils/config';
 import { APP_VERSION, DOCKER_REPO } from 'utils/constants';
 import { rm } from 'utils/files';
 import {
@@ -518,8 +518,7 @@ const networkModel: NetworkModel = {
       actions.setNetworks([...networks]);
       await actions.save();
       // delete the docker volume data from disk
-      const volumeDir = node.implementation.toLocaleLowerCase().replace('-', '');
-      rm(join(network.path, 'volumes', volumeDir, node.name));
+      await rm(nodePath(network, node.implementation, node.name));
       // sync the chart
       await getStoreActions().designer.syncChart(network);
     },
@@ -546,8 +545,7 @@ const networkModel: NetworkModel = {
       actions.setNetworks([...networks]);
       await actions.save();
       // delete the docker volume data from disk
-      const volumeDir = node.implementation.toLocaleLowerCase().replace('-', '');
-      rm(join(network.path, 'volumes', volumeDir, node.name));
+      await rm(nodePath(network, node.implementation, node.name));
       // sync the chart
       await getStoreActions().designer.syncChart(network);
     },
@@ -615,8 +613,7 @@ const networkModel: NetworkModel = {
       actions.setNetworks([...networks]);
       await actions.save();
       // delete the docker volume data from disk
-      const volumeDir = node.implementation.toLocaleLowerCase().replace('-', '');
-      rm(join(network.path, 'volumes', volumeDir, node.name));
+      await rm(nodePath(network, node.implementation, node.name));
       if (network.status === Status.Started) {
         // wait for the LN nodes to come back online then update the chart
         await Promise.all(


### PR DESCRIPTION
Closes #1371 

### Description
When a CLN node is removed from a network, its data directory at `volumes/c-lightning/<node-name>/` was not being deleted from the host filesystem. All other implementations cleaned up correctly.
The cause was in `removeLightningNode` in `src/store/models/network.ts`, where the volume directory was derived by stripping hyphens from the implementation name. For `c-lightning`, this produced `clightning` instead of `c-lightning`, so the `rm` call targeted a path that didn't exist. 
The fix replaces this with the existing `nodePath()` utility. The call is also now properly awaited.


### Steps to Test
1. Create a new network with at least one CLN node
2. Start the network
3. Note the directory at `~/.polar/networks/<id>/volumes/c-lightning/<node-name>/` exists
4. Right-click the CLN node and select "Remove."
5. Confirm the removal
6. Check `~/.polar/networks/<id>/volumes/c-lightning/` — the node directory should be deleted
