### PR TITLE
fix: accommodate longer texts in translated wordings

### DIFF
--- a/src/components/designer/lightning/ConnectTab.tsx
+++ b/src/components/designer/lightning/ConnectTab.tsx
@@ -22,9 +22,18 @@ import LncSessionsList from './connect/LncSessionsList';
 const Styled = {
   RadioGroup: styled(Radio.Group)`
     display: flex;
+    flex-wrap: wrap;
     justify-content: center;
+    gap: 8px;
     font-size: 12px;
     margin-bottom: 20px;
+
+     .ant-radio-button-wrapper {
+    white-space: normal;
+    height: auto;
+    padding: 4px 10px;
+    text-align: center;
+    line-height: 1.2;
   `,
   Link: styled.a`
     margin-left: 10px;

--- a/src/components/designer/lightning/ConnectTab.tsx
+++ b/src/components/designer/lightning/ConnectTab.tsx
@@ -28,24 +28,29 @@ const Styled = {
     font-size: 12px;
     margin-bottom: 20px;
 
-     .ant-radio-button-wrapper {
-    white-space: normal;
-    height: auto;
-    padding: 4px 10px;
-    text-align: center;
-    line-height: 1.2;
+    .ant-radio-button-wrapper {
+      white-space: normal;
+      height: auto;
+      padding: 4px 10px;
+      text-align: center;
+      line-height: 1.2;
+    }
   `,
+
   Link: styled.a`
     margin-left: 10px;
     color: inherit;
+
     &:hover {
       opacity: 1;
     }
   `,
+
   BookIcon: styled(BookOutlined)`
     margin-left: 5px;
     color: #aaa;
   `,
+
   LinkIcon: styled(LinkOutlined)`
     margin-left: 5px;
     color: #aaa;

--- a/src/components/designer/lightning/actions/PaymentButtons.tsx
+++ b/src/components/designer/lightning/actions/PaymentButtons.tsx
@@ -8,7 +8,11 @@ import { useStoreActions } from 'store';
 
 const Styled = {
   Button: styled(Button)`
-    width: 50%;
+    flex: 1;
+    min-width: 0;
+    white-space: normal;
+    height: auto;
+    text-align: center;
   `,
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5731,10 +5731,15 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000929, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001565, caniuse-lite@^1.0.30001669:
-  version "1.0.30001793"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz"
-  integrity sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000929, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001565:
+  version "1.0.30001576"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001576.tgz#893be772cf8ee6056d6c1e2d07df365b9ec0a5c4"
+  integrity sha512-ff5BdakGe2P3SQsMsiqmt1Lc8221NR1VzHj5jXN5vBny9A6fpze94HiVV/n7XRosOlsShJcvMv5mdnpjOGCEgg==
+
+caniuse-lite@^1.0.30001669:
+  version "1.0.30001677"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001677.tgz#27c2e2c637e007cfa864a16f7dfe7cde66b38b5f"
+  integrity sha512-fmfjsOlJUpMWu+mAAtZZZHz7UEwsUxIIvu1TJfO1HqFQvB/B+ii0xr9B5HpbZY/mC4XZ8SvjHJqtAY6pDPQEog==
 
 capture-exit@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5731,15 +5731,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000929, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001565:
-  version "1.0.30001576"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001576.tgz#893be772cf8ee6056d6c1e2d07df365b9ec0a5c4"
-  integrity sha512-ff5BdakGe2P3SQsMsiqmt1Lc8221NR1VzHj5jXN5vBny9A6fpze94HiVV/n7XRosOlsShJcvMv5mdnpjOGCEgg==
-
-caniuse-lite@^1.0.30001669:
-  version "1.0.30001677"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001677.tgz#27c2e2c637e007cfa864a16f7dfe7cde66b38b5f"
-  integrity sha512-fmfjsOlJUpMWu+mAAtZZZHz7UEwsUxIIvu1TJfO1HqFQvB/B+ii0xr9B5HpbZY/mC4XZ8SvjHJqtAY6pDPQEog==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000929, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001565, caniuse-lite@^1.0.30001669:
+  version "1.0.30001793"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz"
+  integrity sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Closes #1032
---

## ### Description

This PR fixes an i18n layout issue where some buttons did not have enough space for translated text, causing overflow or text collision in non-English languages (e.g. German, French, etc.).

### Casual explanation

In some languages, button labels become longer than English (like “Zahlungen” or “Creer une facture”), which caused the text to overflow or overlap inside UI buttons. This update makes the buttons flexible so translations fit properly without breaking the layout.

### Technical explanation

* Replaced rigid `Button.Group` layout with a flex-based container
* Enabled `flex-wrap` support for better responsiveness
* Added `min-width: 0` and `white-space: normal` to allow proper text wrapping
* Improved Ant Design `Radio.Group` styling to support multi-line translated labels
* Ensures UI remains stable across all supported languages

---

## ### Steps to Test

1. Start the application locally
2. Navigate to the Lightning node connection / payment UI section
3. Switch language to a longer translation (e.g. German or French)
4. Verify that:

   * Buttons do not overlap
   * Text wraps correctly inside buttons
   * Layout remains aligned and readable
5. Repeat for different node implementations (LND / litd / etc.)

---

## ### Screenshots
<img width="3840" height="1920" alt="InShot_20260525_125221794" src="https://github.com/user-attachments/assets/3acc1807-0522-4e8d-a832-99dedabde479" />
<img width="3840" height="1920" alt="InShot_20260525_125116950" src="https://github.com/user-attachments/assets/146ee056-8f86-46b1-9833-96813ede940f" />

---
