### PR TITLE
feat: detect LND wallet locked state

### DIFF
--- a/electron/lnd/lndProxyServer.ts
+++ b/electron/lnd/lndProxyServer.ts
@@ -253,8 +253,84 @@ export const initLndProxy = (ipc: IpcMain) => {
 };
 
 /**
+ * Separate cache for unauthenticated State RPC clients (TLS only, no macaroon).
+ * Used to query wallet state before the wallet is unlocked/created.
+ */
+let noAuthRpcCache: {
+  [key: string]: LND.StateApi;
+} = {};
+
+const getNoAuthRpc = async (node: LndNode): Promise<LND.StateApi> => {
+  const { name, ports, paths, networkId } = node;
+  const id = `n${networkId}-${name}`;
+  if (!noAuthRpcCache[id]) {
+    const config: LND.LndClientOptions = {
+      socket: `127.0.0.1:${ports.grpc}`,
+      cert: (await readFile(paths.tlsCert)).toString('hex'),
+      macaroon: '',
+    };
+    noAuthRpcCache[id] = LND.StateApi.create(config);
+  }
+  return noAuthRpcCache[id];
+};
+
+/**
+ * Evict both caches for a node. Called when a WalletUnlocker RPC errors,
+ * since a stale cached connection is a likely cause.
+ */
+const evictRpcCache = (node: LndNode) => {
+  const { name, networkId } = node;
+  const id = `n${networkId}-${name}`;
+  delete noAuthRpcCache[id];
+  delete rpcCache[id];
+};
+
+const getState = async (args: { node: LndNode }): Promise<LND.GetStateResponse> => {
+  const rpc = await getNoAuthRpc(args.node);
+  return await rpc.getState();
+};
+
+const walletUnlockerListeners: {
+  [key: string]: (...args: any) => Promise<any>;
+} = {
+  [ipcChannels.getState]: getState,
+};
+
+/**
+ * Register IPC handlers for WalletUnlocker RPCs under the
+ * 'lnd-wallet-unlocker' prefix. Same pattern as initLndProxy
+ * but uses TLS-only gRPC clients (no macaroon).
+ */
+export const initLndWalletUnlockerProxy = (ipc: IpcMain) => {
+  debug('LndWalletUnlockerProxy: initialize');
+  Object.entries(walletUnlockerListeners).forEach(([channel, func]) => {
+    const requestChan = `lnd-${channel}-request`;
+
+    debug(`LndWalletUnlockerProxy: listening for ipc command "${channel}"`);
+    ipc.on(requestChan, async (event, ...args) => {
+      let uniqueChan = `lnd-${channel}-response`;
+      if (args && args[0] && args[0].replyTo) {
+        uniqueChan = args[0].replyTo;
+      }
+      try {
+        const result = await func(...args);
+        debug(`LndWalletUnlockerProxy: send response "${uniqueChan}"`, toJSON(result));
+        event.reply(uniqueChan, result);
+      } catch (err: any) {
+        debug(`LndWalletUnlockerProxy: send error "${uniqueChan}"`, err);
+        if (args && args[0] && args[0].node) {
+          evictRpcCache(args[0].node);
+        }
+        event.reply(uniqueChan, { err: err.message });
+      }
+    });
+  });
+};
+
+/**
  * Clears the cached rpc instances
  */
 export const clearLndProxyCache = () => {
   rpcCache = {};
+  noAuthRpcCache = {};
 };

--- a/electron/windowManager.ts
+++ b/electron/windowManager.ts
@@ -10,6 +10,7 @@ import {
   clearLndProxyCache,
   initLndProxy,
   initLndSubscriptions,
+  initLndWalletUnlockerProxy,
 } from './lnd/lndProxyServer';
 import { startMcpBridge } from './mcpBridge';
 import { initTapdProxy } from './tapd/tapdProxyServer';
@@ -27,6 +28,7 @@ class WindowManager {
       initLitdProxy(ipcMain);
       initAppIpcListener(ipcMain);
       initLndSubscriptions(this.sendMessageToRenderer);
+      initLndWalletUnlockerProxy(ipcMain);
       // Start MCP bridge after main window is created
       if (this.mainWindow) {
         startMcpBridge(this.mainWindow);

--- a/src/components/common/RestartNode.tsx
+++ b/src/components/common/RestartNode.tsx
@@ -23,7 +23,7 @@ const RestartNode: React.FC<Props> = ({ node, menuType }) => {
   const { toggleNode } = useStoreActions(s => s.network);
 
   const disabled = [Status.Starting, Status.Stopping].includes(node.status);
-  const showStop = node.status === Status.Started;
+  const showStop = node.status === Status.Started || node.status === Status.Locked;
 
   const showConfirmModal = (mode: string) => {
     const { name } = node;

--- a/src/components/common/StatusBadge.tsx
+++ b/src/components/common/StatusBadge.tsx
@@ -19,6 +19,7 @@ const badgeStatuses: BadgeStatus = {
   [Status.Stopping]: 'processing',
   [Status.Stopped]: 'default',
   [Status.Error]: 'error',
+  [Status.Locked]: 'warning',
 };
 
 const Styled = {

--- a/src/components/common/StatusButton.tsx
+++ b/src/components/common/StatusButton.tsx
@@ -1,9 +1,9 @@
 import React, { ReactNode } from 'react';
+import { PlayCircleOutlined, StopOutlined, WarningOutlined } from '@ant-design/icons';
 import styled from '@emotion/styled';
 import { Button } from 'antd';
-import { Status } from 'shared/types';
 import { ButtonType } from 'antd/lib/button';
-import { PlayCircleOutlined, StopOutlined, WarningOutlined } from '@ant-design/icons';
+import { Status } from 'shared/types';
 
 const Styled = {
   Button: styled(Button, {
@@ -54,6 +54,12 @@ const config: {
     type: 'primary',
     danger: true,
     icon: <WarningOutlined />,
+  },
+  [Status.Locked]: {
+    label: 'Stop',
+    type: 'primary',
+    danger: true,
+    icon: <StopOutlined />,
   },
 };
 

--- a/src/components/common/StatusTag.tsx
+++ b/src/components/common/StatusTag.tsx
@@ -19,6 +19,7 @@ const StatusTag: React.FC<StatusTagProps> = ({ status }) => {
     [Status.Stopping]: 'blue',
     [Status.Stopped]: statusTag.stopped,
     [Status.Error]: 'red',
+    [Status.Locked]: 'orange',
   };
 
   return <Tag color={statusColors[status]}>{t(`enums.status.${Status[status]}`)}</Tag>;

--- a/src/components/designer/NodeContextMenu.tsx
+++ b/src/components/designer/NodeContextMenu.tsx
@@ -6,8 +6,8 @@ import { useStoreState } from 'store';
 import {
   AdvancedOptionsButton,
   RemoveNode,
-  RestartNode,
   RenameNodeButton,
+  RestartNode,
 } from 'components/common';
 import { ViewLogsButton } from 'components/dockerLogs';
 import { OpenTerminalButton } from 'components/terminal';
@@ -90,7 +90,11 @@ const NodeContextMenu: React.FC<Props> = ({ node: { id }, children }) => {
       <SendOnChainButton type="menu" node={node as BitcoinNode} />,
       isStarted && isBackend,
     ),
-    addItemIf('terminal', <OpenTerminalButton type="menu" node={node} />, isStarted),
+    addItemIf(
+      'terminal',
+      <OpenTerminalButton type="menu" node={node} />,
+      [Status.Started, Status.Locked].includes(node.status),
+    ),
     isStarted ? [{ type: 'divider' }] : [],
     addItemIf(
       'start',
@@ -100,12 +104,14 @@ const NodeContextMenu: React.FC<Props> = ({ node: { id }, children }) => {
     addItemIf(
       'stop',
       <RestartNode menuType="stop" node={node} />,
-      [Status.Started].includes(node.status),
+      [Status.Started, Status.Locked].includes(node.status),
     ),
     addItemIf(
       'logs',
       <ViewLogsButton type="menu" node={node} />,
-      [Status.Starting, Status.Started, Status.Error].includes(node.status),
+      [Status.Starting, Status.Started, Status.Error, Status.Locked].includes(
+        node.status,
+      ),
     ),
     addItemIf('rename', <RenameNodeButton type="menu" node={node} />),
     addItemIf('options', <AdvancedOptionsButton type="menu" node={node} />),

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -4,6 +4,7 @@
   "enums.status.Stopping": "Stopping",
   "enums.status.Stopped": "Stopped",
   "enums.status.Error": "Error",
+  "enums.status.Locked": "Locked",
   "cmps.forms.required": "required",
   "cmps.common.form.DockerCommandInput.label": "Docker Startup Command",
   "cmps.common.form.DockerCommandInput.help": "The docker command to execute when starting this node. If left blank, the default command will be used.",

--- a/src/lib/lightning/lnd/lndProxyClient.spec.ts
+++ b/src/lib/lightning/lnd/lndProxyClient.spec.ts
@@ -173,4 +173,9 @@ describe('LndService', () => {
     lndProxyClient.unsubscribeEvents(node);
     expect(lndProxyClient.streamer.unsubscribe).not.toHaveBeenCalled();
   });
+
+  it('should call the getState ipc', () => {
+    lndProxyClient.getState(node);
+    expect(lndProxyClient.ipc).toHaveBeenCalledWith(ipcChannels.getState, { node });
+  });
 });

--- a/src/lib/lightning/lnd/lndProxyClient.ts
+++ b/src/lib/lightning/lnd/lndProxyClient.ts
@@ -114,6 +114,10 @@ class LndProxyClient {
       debug('LndProxyClient: unsubscribeEvents deleted', channel);
     }
   }
+
+  async getState(node: LndNode): Promise<LND.GetStateResponse> {
+    return await this.ipc(ipcChannels.getState, { node });
+  }
 }
 
 export default new LndProxyClient();

--- a/src/lib/lightning/lnd/lndService.spec.ts
+++ b/src/lib/lightning/lnd/lndService.spec.ts
@@ -301,17 +301,39 @@ describe('LndService', () => {
 
   describe('waitUntilOnline', () => {
     it('should wait successfully', async () => {
+      lndProxyClient.getState = jest.fn().mockResolvedValue({ state: 'RPC_ACTIVE' });
       lndProxyClient.getInfo = jest.fn().mockResolvedValue({});
       await expect(lndService.waitUntilOnline(node)).resolves.not.toThrow();
       expect(lndProxyClient.getInfo).toHaveBeenCalledTimes(1);
     });
 
     it('should throw error if waiting fails', async () => {
+      lndProxyClient.getState = jest.fn().mockResolvedValue({ state: 'RPC_ACTIVE' });
       lndProxyClient.getInfo = jest.fn().mockRejectedValue(new Error('test-error'));
       await expect(lndService.waitUntilOnline(node, 0.5, 1)).rejects.toThrow(
         'test-error',
       );
       expect(lndProxyClient.getInfo).toHaveBeenCalledTimes(4);
+    });
+
+    it('should not abort on a single transient NON_EXISTING read', async () => {
+      // a --noseedbackup node briefly reports NON_EXISTING before it
+      // auto-creates its wallet; a lone read shouldn't be mistaken for a
+      // wallet that needs to be initialized
+      lndProxyClient.getState = jest
+        .fn()
+        .mockResolvedValueOnce({ state: 'NON_EXISTING' })
+        .mockResolvedValue({ state: 'RPC_ACTIVE' });
+      lndProxyClient.getInfo = jest.fn().mockResolvedValue({});
+      await expect(lndService.waitUntilOnline(node, 0.5, 10)).resolves.not.toThrow();
+    });
+
+    it('should abort once NON_EXISTING is read twice in a row', async () => {
+      lndProxyClient.getState = jest.fn().mockResolvedValue({ state: 'NON_EXISTING' });
+      await expect(lndService.waitUntilOnline(node, 0.5, 10)).rejects.toThrow(
+        'wallet-not-initialized',
+      );
+      expect(lndProxyClient.getInfo).not.toHaveBeenCalled();
     });
   });
 

--- a/src/lib/lightning/lnd/lndService.spec.ts
+++ b/src/lib/lightning/lnd/lndService.spec.ts
@@ -316,6 +316,14 @@ describe('LndService', () => {
       expect(lndProxyClient.getInfo).toHaveBeenCalledTimes(4);
     });
 
+    it('should abort immediately when wallet is LOCKED', async () => {
+      lndProxyClient.getState = jest.fn().mockResolvedValue({ state: 'LOCKED' });
+      await expect(lndService.waitUntilOnline(node, 0.5, 1)).rejects.toThrow(
+        'wallet-locked',
+      );
+      expect(lndProxyClient.getInfo).not.toHaveBeenCalled();
+    });
+
     it('should not abort on a single transient NON_EXISTING read', async () => {
       // a --noseedbackup node briefly reports NON_EXISTING before it
       // auto-creates its wallet; a lone read shouldn't be mistaken for a
@@ -334,6 +342,17 @@ describe('LndService', () => {
         'wallet-not-initialized',
       );
       expect(lndProxyClient.getInfo).not.toHaveBeenCalled();
+    });
+
+    it('should keep retrying while state is not yet RPC_ACTIVE', async () => {
+      lndProxyClient.getState = jest
+        .fn()
+        .mockResolvedValueOnce({ state: 'WAITING_TO_START' })
+        .mockResolvedValueOnce({ state: 'WAITING_TO_START' })
+        .mockResolvedValue({ state: 'RPC_ACTIVE' });
+      lndProxyClient.getInfo = jest.fn().mockResolvedValue({});
+      await expect(lndService.waitUntilOnline(node, 0.5, 10)).resolves.not.toThrow();
+      expect(lndProxyClient.getState).toHaveBeenCalledTimes(3);
     });
   });
 

--- a/src/lib/lightning/lnd/lndService.ts
+++ b/src/lib/lightning/lnd/lndService.ts
@@ -4,7 +4,7 @@ import { PendingChannel } from 'shared/lndDefaults';
 import { LightningNode, LndNode, OpenChannelOptions } from 'shared/types';
 import * as PLN from 'lib/lightning/types';
 import { LightningService } from 'types';
-import { waitFor } from 'utils/async';
+import { AbortWaitError, waitFor } from 'utils/async';
 import { lndProxyClient as proxy } from './';
 import { mapOpenChannel, mapPendingChannel } from './mappers';
 
@@ -218,6 +218,11 @@ class LndService implements LightningService {
     };
   }
 
+  async getWalletState(node: LightningNode): Promise<LND.WalletState> {
+    const res = await proxy.getState(this.cast(node));
+    return res.state;
+  }
+
   /**
    * Helper function to continually query the LND node until a successful
    * response is received or it times out
@@ -227,8 +232,30 @@ class LndService implements LightningService {
     interval = 3 * 1000, // check every 3 seconds
     timeout = 120 * 1000, // timeout after 120 seconds
   ): Promise<void> {
+    // a node started with --noseedbackup auto-creates its wallet shortly after
+    // the State service comes up, so it can briefly report NON_EXISTING before
+    // that happens. Only treat NON_EXISTING as needing user action once it's
+    // been observed twice in a row, to avoid mistaking that window for a
+    // wallet that was never initialized.
+    let nonExistingCount = 0;
     return waitFor(
       async () => {
+        const state = await this.getWalletState(node);
+        if (state === 'LOCKED') {
+          // node is running but needs user action
+          throw new AbortWaitError('wallet-locked');
+        }
+        if (state === 'NON_EXISTING') {
+          nonExistingCount += 1;
+          if (nonExistingCount < 2) {
+            throw new Error('waiting for wallet state to stabilize');
+          }
+          throw new AbortWaitError('wallet-not-initialized');
+        }
+        nonExistingCount = 0;
+        if (state !== 'RPC_ACTIVE' && state !== 'SERVER_ACTIVE') {
+          throw new Error(`waiting for RPC_ACTIVE, current state: ${state}`);
+        }
         await this.getInfo(node);
       },
       interval,

--- a/src/shared/ipcChannels.ts
+++ b/src/shared/ipcChannels.ts
@@ -25,6 +25,7 @@ export default {
   setupListener: 'setup-listener',
   removeListener: 'remove-listener',
   subscribeChannelEvents: 'subscribe-channel-events',
+  getState: 'get-state',
   // tapd proxy channels
   tapd: {
     listAssets: 'tapd-list-assets',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -4,6 +4,7 @@ export enum Status {
   Stopping,
   Stopped,
   Error,
+  Locked,
 }
 
 export interface CommonNode {

--- a/src/store/models/mcp/network/restartNode.ts
+++ b/src/store/models/mcp/network/restartNode.ts
@@ -70,7 +70,11 @@ export const restartNodeTool = thunk<
     const node = findNode(network, args.nodeName);
 
     // Check if node can be restarted
-    if (node.status !== Status.Started && node.status !== Status.Error) {
+    if (
+      node.status !== Status.Started &&
+      node.status !== Status.Error &&
+      node.status !== Status.Locked
+    ) {
       throw new Error(
         `Cannot restart node "${args.nodeName}". Node is currently ${
           Status[node.status]

--- a/src/store/models/mcp/network/stopNode.ts
+++ b/src/store/models/mcp/network/stopNode.ts
@@ -64,7 +64,7 @@ export const stopNodeTool = thunk<
   const node = findNode(network, args.nodeName);
 
   // Check if node can be stopped
-  if (node.status !== Status.Started) {
+  if (node.status !== Status.Started && node.status !== Status.Locked) {
     throw new Error(
       `Cannot stop node "${args.nodeName}". Node is currently ${Status[node.status]}. ` +
         'Only Started nodes can be stopped.',

--- a/src/store/models/network.spec.ts
+++ b/src/store/models/network.spec.ts
@@ -3,7 +3,7 @@ import * as log from 'electron-log';
 import { waitFor } from '@testing-library/react';
 import detectPort from 'detect-port';
 import { createStore } from 'easy-peasy';
-import { NodeImplementation, Status, TapdNode } from 'shared/types';
+import { CLightningNode, NodeImplementation, Status, TapdNode } from 'shared/types';
 import { AutoMineMode, CustomImage, Network } from 'types';
 import * as asyncUtil from 'utils/async';
 import { initChartFromNetwork } from 'utils/chart';
@@ -952,6 +952,56 @@ describe('Network model', () => {
       node = firstNetwork().nodes.lightning[4];
       expect(node.ports.rest).toBe(8085);
     });
+
+    it('should start the node with its updated ports, not the stale ones', async () => {
+      const staleNode = firstNetwork().nodes.lightning[1] as CLightningNode;
+      const staleRestPort = staleNode.ports.rest;
+      const portsInUse = [staleRestPort];
+      detectPortMock.mockImplementation(port =>
+        Promise.resolve(portsInUse.includes(port) ? port + 1 : port),
+      );
+      const { toggleNode } = store.getActions().network;
+      await toggleNode(staleNode);
+      expect(injections.dockerService.startNode).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          ports: expect.objectContaining({ rest: staleRestPort + 1 }),
+        }),
+      );
+    });
+
+    it('should fall back to the passed-in node if it is renamed elsewhere while ports are being checked', async () => {
+      const targetNode = firstNetwork().nodes.lightning[1] as CLightningNode;
+      const originalName = targetNode.name;
+      const conflictPort = targetNode.ports.rest;
+
+      detectPortMock.mockImplementation(async (port: number) => {
+        if (port === conflictPort) {
+          const { setNetworks } = store.getActions().network;
+          const network = firstNetwork();
+          setNetworks([
+            {
+              ...network,
+              nodes: {
+                ...network.nodes,
+                lightning: network.nodes.lightning.map(n =>
+                  n.name === originalName ? { ...n, name: 'renamed-elsewhere' } : n,
+                ),
+              },
+            },
+          ]);
+          return port + 1;
+        }
+        return port;
+      });
+
+      const { toggleNode } = store.getActions().network;
+      await toggleNode(targetNode);
+      expect(injections.dockerService.startNode).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ name: originalName }),
+      );
+    });
   });
 
   describe('TAP network', () => {
@@ -1080,6 +1130,20 @@ describe('Network model', () => {
       bitcoin[0].type = 'asdf' as any;
       await monitorStartup(bitcoin);
       expect(bitcoinServiceMock.waitUntilOnline).not.toHaveBeenCalled();
+    });
+
+    it('should set lightning node status to Locked when waitUntilOnline aborts', async () => {
+      lightningServiceMock.waitUntilOnline.mockRejectedValue(
+        new asyncUtil.AbortWaitError('wallet-locked'),
+      );
+      const { monitorStartup } = store.getActions().network;
+      await monitorStartup(firstNetwork().nodes.lightning);
+      await waitFor(() => {
+        const { lightning } = firstNetwork().nodes;
+        lightning
+          .filter(n => n.implementation === 'LND')
+          .forEach(n => expect(n.status).toBe(Status.Locked));
+      });
     });
   });
 

--- a/src/store/models/network.ts
+++ b/src/store/models/network.ts
@@ -803,7 +803,10 @@ const networkModel: NetworkModel = {
   }),
   stopAll: thunk(async (actions, _, { getState }) => {
     let networks = getState().networks.filter(
-      n => n.status === Status.Started || n.status === Status.Stopping,
+      n =>
+        n.status === Status.Started ||
+        n.status === Status.Stopping ||
+        n.status === Status.Locked,
     );
     if (networks.length === 0) {
       ipcRenderer.send('docker-shut-down');
@@ -813,7 +816,10 @@ const networkModel: NetworkModel = {
     });
     setInterval(async () => {
       networks = getState().networks.filter(
-        n => n.status === Status.Started || n.status === Status.Stopping,
+        n =>
+          n.status === Status.Started ||
+          n.status === Status.Stopping ||
+          n.status === Status.Locked,
       );
       if (networks.length === 0) {
         await actions.save();
@@ -826,7 +832,7 @@ const networkModel: NetworkModel = {
     if (!network) throw new Error(l('networkByIdErr', { networkId }));
     if (network.status === Status.Stopped || network.status === Status.Error) {
       await actions.start(network.id);
-    } else if (network.status === Status.Started) {
+    } else if (network.status === Status.Started || network.status === Status.Locked) {
       await actions.stop(network.id);
     }
     await actions.save();
@@ -851,7 +857,7 @@ const networkModel: NetworkModel = {
       }
       await injections.dockerService.startNode(network, node);
       actions.monitorStartup([node]);
-    } else if (node.status === Status.Started) {
+    } else if (node.status === Status.Started || node.status === Status.Locked) {
       // stop the node container
       actions.setStatus({ id: network.id, status: Status.Stopping, only });
       await injections.dockerService.stopNode(network, node);
@@ -1125,7 +1131,7 @@ const networkModel: NetworkModel = {
   }),
   renameNode: thunk(
     async (actions, { node, newName }, { getState, injections, getStoreActions }) => {
-      const wasStarted = node.status === Status.Started;
+      const wasStarted = node.status === Status.Started || node.status === Status.Locked;
 
       if (wasStarted) {
         await actions.stop(node.networkId);

--- a/src/store/models/network.ts
+++ b/src/store/models/network.ts
@@ -15,7 +15,7 @@ import {
   TapNode,
 } from 'shared/types';
 import { AutoMineMode, CustomImage, Network, Simulation, StoreInjections } from 'types';
-import { delay } from 'utils/async';
+import { AbortWaitError, delay } from 'utils/async';
 import { initChartFromNetwork } from 'utils/chart';
 import { nodePath } from 'utils/config';
 import { APP_VERSION, DOCKER_REPO } from 'utils/constants';
@@ -883,9 +883,13 @@ const networkModel: NetworkModel = {
               .then(async () => {
                 actions.setStatus({ id, status: Status.Started, only: ln.name });
               })
-              .catch(error =>
-                actions.setStatus({ id, status: Status.Error, only: ln.name, error }),
-              );
+              .catch(error => {
+                if (error instanceof AbortWaitError && ln.implementation === 'LND') {
+                  actions.setStatus({ id, status: Status.Locked, only: ln.name });
+                } else {
+                  actions.setStatus({ id, status: Status.Error, only: ln.name, error });
+                }
+              });
           } else {
             const litd = ln as LitdNode;
             promise = injections.litdService

--- a/src/store/models/network.ts
+++ b/src/store/models/network.ts
@@ -852,6 +852,13 @@ const networkModel: NetworkModel = {
         actions.updateNodePorts({ id: node.networkId, ports });
         // re-fetch the network with the updated ports
         network = getState().networks.find(n => n.id === networkId) as Network;
+        // re-fetch the node so monitorStartup uses the updated ports, not the stale ones
+        const updatedNode = [
+          ...network.nodes.lightning,
+          ...network.nodes.bitcoin,
+          ...network.nodes.tap,
+        ].find(n => n.name === node.name);
+        if (updatedNode) node = updatedNode;
         await actions.save();
         await injections.dockerService.saveComposeFile(network);
       }

--- a/src/utils/async.spec.ts
+++ b/src/utils/async.spec.ts
@@ -1,4 +1,4 @@
-import { delay, waitFor } from './async';
+import { AbortWaitError, delay, waitFor } from './async';
 import { mockProperty } from './tests';
 
 describe('Async Util', () => {
@@ -49,6 +49,14 @@ describe('Async Util', () => {
       await expect(promise).resolves.toBe(true);
       // confirm the spy was called
       expect(spy).toHaveBeenCalled();
+    });
+
+    it('should abort on AbortWaitError thrown inside the interval', async () => {
+      const condition = jest
+        .fn()
+        .mockRejectedValueOnce(new Error('not-yet'))
+        .mockRejectedValue(new AbortWaitError('abort-reason'));
+      await expect(waitFor(condition, 10, 100)).rejects.toThrow('abort-reason');
     });
   });
 });

--- a/src/utils/async.ts
+++ b/src/utils/async.ts
@@ -22,8 +22,10 @@ export const waitFor = async (
     const result = await conditionFunc();
     // if the condition succeeds, then return immediately
     return Promise.resolve(result);
-  } catch {
+  } catch (error) {
     // do nothing if the condition fails the first time
+    // unless when abortWaitFor is called
+    if (error instanceof AbortWaitError) throw error;
   }
 
   // return a promise that will resolve when the condition is true
@@ -43,9 +45,25 @@ export const waitFor = async (
           clearInterval(timer);
           return reject(error);
         }
+        // reject immediately for user action
+        if (error instanceof AbortWaitError) {
+          clearInterval(timer);
+          return reject(error);
+        }
       }
       // decrement the number of times to check in each iteration
       timesToCheck -= 1;
     }, interval);
   });
 };
+
+/**
+ * Thrown inside a conditionFunc to immediately abort waitFor without retrying.
+ * Used for states that need user action
+ */
+export class AbortWaitError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AbortWaitError';
+  }
+}

--- a/src/utils/network.spec.ts
+++ b/src/utils/network.spec.ts
@@ -26,6 +26,7 @@ import {
   getOpenPortRange,
   getOpenPorts,
   getTapdFilePaths,
+  isNodeRunning,
   mapToTapd,
   OpenPorts,
   renameNode,
@@ -375,6 +376,33 @@ describe('Network Utils', () => {
       const lnd2 = network.nodes.lightning[4] as LndNode;
       expect(ports[lnd2.name].grpc).toBe(lnd2.ports.grpc + 1);
       expect(ports[lnd2.name].rest).toBe(lnd2.ports.rest + 1);
+    });
+
+    it('should not update ports for locked nodes', async () => {
+      mockDetectPort.mockImplementation(port => Promise.resolve(port + 1));
+      network.nodes.lightning[0].status = Status.Locked;
+      const ports = (await getOpenPorts(network)) as OpenPorts;
+      expect(ports).toBeDefined();
+      // a locked node is still holding its ports, so they should not be changed
+      expect(ports[network.nodes.lightning[0].name]).toBeUndefined();
+      // bob ports should change
+      const lnd2 = network.nodes.lightning[4] as LndNode;
+      expect(ports[lnd2.name].grpc).toBe(lnd2.ports.grpc + 1);
+      expect(ports[lnd2.name].rest).toBe(lnd2.ports.rest + 1);
+    });
+  });
+
+  describe('isNodeRunning', () => {
+    it('should return true for Started and Locked', () => {
+      expect(isNodeRunning(Status.Started)).toBe(true);
+      expect(isNodeRunning(Status.Locked)).toBe(true);
+    });
+
+    it('should return false for all other statuses', () => {
+      expect(isNodeRunning(Status.Stopped)).toBe(false);
+      expect(isNodeRunning(Status.Starting)).toBe(false);
+      expect(isNodeRunning(Status.Stopping)).toBe(false);
+      expect(isNodeRunning(Status.Error)).toBe(false);
     });
   });
 

--- a/src/utils/network.ts
+++ b/src/utils/network.ts
@@ -782,6 +782,14 @@ export interface OpenPorts {
 }
 
 /**
+ * Returns true if the node's container is up and holding its own ports, whether
+ * fully started or waiting on user action (e.g. a locked wallet)
+ * @param status the node's current status
+ */
+export const isNodeRunning = (status: Status): boolean =>
+  status === Status.Started || status === Status.Locked;
+
+/**
  * Checks if the ports specified on the nodes are available on the host OS. If not,
  * return new ports that are confirmed available
  * @param network the network with nodes to verify ports of
@@ -789,8 +797,8 @@ export interface OpenPorts {
 export const getOpenPorts = async (network: Network): Promise<OpenPorts | undefined> => {
   const ports: OpenPorts = {};
 
-  // filter out nodes that are already started since their ports are in use by themselves
-  const bitcoin = network.nodes.bitcoin.filter(n => n.status !== Status.Started);
+  // filter out nodes that are already running since their ports are in use by themselves
+  const bitcoin = network.nodes.bitcoin.filter(n => !isNodeRunning(n.status));
   if (bitcoin.length) {
     let existingPorts = bitcoin.map(n => n.ports.rpc);
     let openPorts = await getOpenPortRange(existingPorts);
@@ -836,8 +844,8 @@ export const getOpenPorts = async (network: Network): Promise<OpenPorts | undefi
 
   let { lnd, clightning, eclair, litd, tapd } = groupNodes(network);
 
-  // filter out nodes that are already started since their ports are in use by themselves
-  lnd = lnd.filter(n => n.status !== Status.Started);
+  // filter out nodes that are already running since their ports are in use by themselves
+  lnd = lnd.filter(n => !isNodeRunning(n.status));
   if (lnd.length) {
     let existingPorts = lnd.map(n => n.ports.grpc);
     let openPorts = await getOpenPortRange(existingPorts);
@@ -870,7 +878,7 @@ export const getOpenPorts = async (network: Network): Promise<OpenPorts | undefi
     }
   }
 
-  clightning = clightning.filter(n => n.status !== Status.Started);
+  clightning = clightning.filter(n => !isNodeRunning(n.status));
   if (clightning.length) {
     let existingPorts = clightning.map(n => n.ports.rest);
     let openPorts = await getOpenPortRange(existingPorts);
@@ -900,7 +908,7 @@ export const getOpenPorts = async (network: Network): Promise<OpenPorts | undefi
     }
   }
 
-  eclair = eclair.filter(n => n.status !== Status.Started);
+  eclair = eclair.filter(n => !isNodeRunning(n.status));
   if (eclair.length) {
     let existingPorts = eclair.map(n => n.ports.rest);
     let openPorts = await getOpenPortRange(existingPorts);
@@ -922,7 +930,7 @@ export const getOpenPorts = async (network: Network): Promise<OpenPorts | undefi
     }
   }
 
-  litd = litd.filter(n => n.status !== Status.Started);
+  litd = litd.filter(n => !isNodeRunning(n.status));
   if (litd.length) {
     let existingPorts = litd.map(n => n.ports.rest);
     let openPorts = await getOpenPortRange(existingPorts);
@@ -963,7 +971,7 @@ export const getOpenPorts = async (network: Network): Promise<OpenPorts | undefi
     }
   }
 
-  tapd = tapd.filter(n => n.status !== Status.Started);
+  tapd = tapd.filter(n => !isNodeRunning(n.status));
   if (tapd.length) {
     let existingPorts = tapd.map(n => n.ports.grpc);
     let openPorts = await getOpenPortRange(existingPorts);


### PR DESCRIPTION
Closes #470

### Description

This PR implements wallet locked state detection for LND nodes. Currently, Polar starts all LND nodes with the `--noseedbackup` flag, which skips wallet initialization and makes the node immediately available. This PR lets users start LND nodes in a locked state by removing the `--noseedbackup` flag from the node's default command in  `advanced options` before the initial start.

### Steps to Test

1. Click "Create Network"
2. Create the network with LND nodes. 
3. Open the Advanced Options modal for a node, remove  `--noseedbackup` from the default command, and save.
4. Start the network.
5. Verify the LND node shows a "Locked" status badge instead of "Started" or "Error"
6. Open a terminal on a locked node and run `lncli state` to confirm it returns `NON_EXISTING.`

### Screenshots

<img width="1598" height="718" alt="image" src="https://github.com/user-attachments/assets/a3c5cf23-cbd6-46e0-bda2-a204549a474e" />
