### PR TITLE
docs: add AI policy doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -297,3 +297,5 @@ If you would like to fix a bug or implement a new feature, here are the recommen
    $ git push
    ```
 1. Open a pull request on GitHub ([docs](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork))
+
+If you use AI tools while contributing, please read and follow the [AI policy](docs/ai-policy.md)

--- a/docs/ai-policy.md
+++ b/docs/ai-policy.md
@@ -1,0 +1,50 @@
+# AI Policy
+
+Using AI/LLMs as tools for coding is welcome, provided that such use
+adheres to the following policy, adds value, and does not waste the
+community's time.
+
+A high bar is held for all contributions to this project. The maintainers
+remain responsible for any code that is merged and released, and contributors
+are expected to be responsible for any code they submit.
+
+**AI should not be used to generate comments when communicating with
+maintainers and other contributors.** Comments are expected to be written by
+humans. Comments that are believed to be written by AI may be hidden or
+moderated without notice.
+
+If you are opening an issue, you should be able to describe the problem in
+your own words.
+
+You should only open a pull request if you:
+
+- know the language the code is written in
+- could have written the code yourself
+- reviewed the code yourself
+- understand the existing surrounding code and the effect of the suggested
+  changes
+- have actually run Polar with your changes and verified the behavior
+  yourself
+
+You must also be able to explain the pull request changes in your own words.
+This includes the pull request body and responses to questions. **Do not copy
+responses from the AI when replying to questions from reviewers.**
+
+This project requires a human author in the loop who understands the work
+produced by AI. **Pull requests should not be opened or driven by autonomous
+agents.** A human author must choose the work, understand the change, and be
+responsible for the contribution. Pull requests that appear in violation of
+this may be closed without notice.
+
+AI is useful when communicating as a non-native English speaker. If you are
+using AI to edit your comments for this purpose, please take the time to
+ensure it reflects your own voice and ideas. If using AI for translation, we
+recommend writing in your native language and including the AI translation in
+a quote block.
+
+This policy was adapted from [Bitcoin Core's AI policy], which was adapted
+from [ripgrep's AI policy], which was adapted from [uv's AI policy].
+
+[Bitcoin Core's AI policy]: https://github.com/bitcoin/bitcoin/blob/master/doc/AI_POLICY.md
+[ripgrep's AI policy]: https://github.com/BurntSushi/ripgrep/blob/f0cec341ab95c25c691ad3d5754d4bd9eedde21f/AI_POLICY.md
+[uv's AI policy]: https://github.com/astral-sh/.github/blob/c5187e200db51bfe11d56e13053d29bd3793fdd8/AI_POLICY.md


### PR DESCRIPTION
Closes #1379

### Description

This PR adds an AI contribution policy to the project. It adds `ai-policy.md` to the `docs` directory and adds a line to `CONTRIBUTING.md` linking to the policy.
