### PR TITLE
chore(deps): add Dependabot config for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    # Do NOT enable automerge here to keep zero-risk: maintainers review updates before merging.
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"


### PR DESCRIPTION
## Summary 

Add Dependabot configuration to automatically open dependency update PRs weekly for npm and GitHub Actions.

## Why 

Keeps dependencies current and reduces bit-rot.
Safe: Dependabot only opens PRs for maintainers to review; no code or runtime changes are applied automatically.

