### PR TITLE
fix: harden LND locked-state handling

### DIFF
--- a/src/components/common/RenameNodeModal.spec.tsx
+++ b/src/components/common/RenameNodeModal.spec.tsx
@@ -96,6 +96,13 @@ describe('RenameNodeModal', () => {
     ).toBeInTheDocument();
   });
 
+  it('should render a alert for locked nodes', async () => {
+    const { getByText } = await renderComponent(Status.Locked);
+    expect(
+      getByText('The network will be restarted to perform this operation'),
+    ).toBeInTheDocument();
+  });
+
   it('should hide modal when cancel is clicked', async () => {
     const { getByText, queryByText } = await renderComponent();
     const btn = getByText('Cancel');

--- a/src/components/common/RenameNodeModal.tsx
+++ b/src/components/common/RenameNodeModal.tsx
@@ -59,7 +59,7 @@ const RenameNodeModal: React.FC<Props> = ({ network }) => {
         initialValues={{ newNodeName: oldNodeName }}
         onFinish={handleSubmit}
       >
-        {node?.status === Status.Started ? (
+        {node?.status === Status.Started || node?.status === Status.Locked ? (
           <Alert type="warning" message={l('alert')} />
         ) : null}
         <Form.Item

--- a/src/lib/lightning/lnd/lndService.spec.ts
+++ b/src/lib/lightning/lnd/lndService.spec.ts
@@ -324,23 +324,30 @@ describe('LndService', () => {
       expect(lndProxyClient.getInfo).not.toHaveBeenCalled();
     });
 
-    it('should not abort on a single transient NON_EXISTING read', async () => {
-      // a --noseedbackup node briefly reports NON_EXISTING before it
-      // auto-creates its wallet; a lone read shouldn't be mistaken for a
-      // wallet that needs to be initialized
+    it('should keep waiting on NON_EXISTING when the node uses --noseedbackup', async () => {
+      // the default command contains --noseedbackup, so the node creates its own
+      // wallet and NON_EXISTING is just a phase of startup
       lndProxyClient.getState = jest
         .fn()
+        .mockResolvedValueOnce({ state: 'NON_EXISTING' })
         .mockResolvedValueOnce({ state: 'NON_EXISTING' })
         .mockResolvedValue({ state: 'RPC_ACTIVE' });
       lndProxyClient.getInfo = jest.fn().mockResolvedValue({});
       await expect(lndService.waitUntilOnline(node, 0.5, 10)).resolves.not.toThrow();
+      expect(lndProxyClient.getInfo).toHaveBeenCalledTimes(1);
     });
 
-    it('should abort once NON_EXISTING is read twice in a row', async () => {
+    it('should abort on NON_EXISTING when the node does not use --noseedbackup', async () => {
+      const lockedNode = {
+        ...node,
+        docker: { ...node.docker, command: 'lnd --alias={{name}}' },
+      };
       lndProxyClient.getState = jest.fn().mockResolvedValue({ state: 'NON_EXISTING' });
-      await expect(lndService.waitUntilOnline(node, 0.5, 10)).rejects.toThrow(
+      lndProxyClient.getInfo = jest.fn().mockResolvedValue({});
+      await expect(lndService.waitUntilOnline(lockedNode, 0.5, 10)).rejects.toThrow(
         'wallet-not-initialized',
       );
+      expect(lndProxyClient.getState).toHaveBeenCalledTimes(1);
       expect(lndProxyClient.getInfo).not.toHaveBeenCalled();
     });
 

--- a/src/lib/lightning/lnd/lndService.ts
+++ b/src/lib/lightning/lnd/lndService.ts
@@ -5,6 +5,7 @@ import { LightningNode, LndNode, OpenChannelOptions } from 'shared/types';
 import * as PLN from 'lib/lightning/types';
 import { LightningService } from 'types';
 import { AbortWaitError, waitFor } from 'utils/async';
+import { getDefaultCommand } from 'utils/network';
 import { lndProxyClient as proxy } from './';
 import { mapOpenChannel, mapPendingChannel } from './mappers';
 
@@ -232,12 +233,11 @@ class LndService implements LightningService {
     interval = 3 * 1000, // check every 3 seconds
     timeout = 120 * 1000, // timeout after 120 seconds
   ): Promise<void> {
-    // a node started with --noseedbackup auto-creates its wallet shortly after
-    // the State service comes up, so it can briefly report NON_EXISTING before
-    // that happens. Only treat NON_EXISTING as needing user action once it's
-    // been observed twice in a row, to avoid mistaking that window for a
-    // wallet that was never initialized.
-    let nonExistingCount = 0;
+    // a node started with --noseedbackup creates its own wallet moments after the
+    // State service comes up, so NON_EXISTING is just a phase of its startup.
+    // Without the flag, the wallet only exists once the user creates it.
+    const command = node.docker.command || getDefaultCommand('LND', node.version);
+    const autoCreatesWallet = command.includes('noseedbackup');
     return waitFor(
       async () => {
         const state = await this.getWalletState(node);
@@ -246,13 +246,10 @@ class LndService implements LightningService {
           throw new AbortWaitError('wallet-locked');
         }
         if (state === 'NON_EXISTING') {
-          nonExistingCount += 1;
-          if (nonExistingCount < 2) {
-            throw new Error('waiting for wallet state to stabilize');
-          }
-          throw new AbortWaitError('wallet-not-initialized');
+          // the node cannot create the wallet itself, so it needs user action
+          if (!autoCreatesWallet) throw new AbortWaitError('wallet-not-initialized');
+          throw new Error('waiting for the wallet to be created');
         }
-        nonExistingCount = 0;
         if (state !== 'RPC_ACTIVE' && state !== 'SERVER_ACTIVE') {
           throw new Error(`waiting for RPC_ACTIVE, current state: ${state}`);
         }

--- a/src/store/models/network.spec.ts
+++ b/src/store/models/network.spec.ts
@@ -429,6 +429,29 @@ describe('Network model', () => {
       expect(firstNetwork().nodes.bitcoin).toHaveLength(1);
     });
 
+    it('should remove a bitcoin node from the chart when a LN node is locked', async () => {
+      const { removeBitcoinNode, setStatus } = store.getActions().network;
+      const { id } = firstNetwork();
+      setStatus({ id, status: Status.Started });
+      lightningServiceMock.waitUntilOnline.mockRejectedValue(
+        new asyncUtil.AbortWaitError('wallet-locked'),
+      );
+      const node = firstNetwork().nodes.bitcoin[0];
+      await expect(removeBitcoinNode({ node })).resolves.not.toThrow();
+      expect(firstNetwork().nodes.bitcoin).toHaveLength(1);
+      const chart = store.getState().designer.allCharts[id];
+      expect(chart.nodes[node.name]).toBeUndefined();
+    });
+
+    it('should throw if a LN node fails to restart for any other reason', async () => {
+      const { removeBitcoinNode, setStatus } = store.getActions().network;
+      const { id } = firstNetwork();
+      setStatus({ id, status: Status.Started });
+      lightningServiceMock.waitUntilOnline.mockRejectedValue(new Error('test-error'));
+      const node = firstNetwork().nodes.bitcoin[0];
+      await expect(removeBitcoinNode({ node })).rejects.toThrow('test-error');
+    });
+
     it('should throw an error if the bitcoin node network id is invalid', async () => {
       const node = firstNetwork().nodes.bitcoin[0];
       node.networkId = 999;

--- a/src/store/models/network.ts
+++ b/src/store/models/network.ts
@@ -622,7 +622,17 @@ const networkModel: NetworkModel = {
       if (network.status === Status.Started) {
         // wait for the LN nodes to come back online then update the chart
         await Promise.all(
-          lightning.map(n => lightningFactory.getService(n).waitUntilOnline(n)),
+          lightning.map(n =>
+            lightningFactory
+              .getService(n)
+              .waitUntilOnline(n)
+              .catch(error => {
+                // a locked node will never come online on its own, but that
+                // shouldn't stop the removed node from leaving the chart
+                if (!(error instanceof AbortWaitError)) throw error;
+                info(`Skipped waiting for '${n.name}'`, error.message);
+              }),
+          ),
         );
       }
       // remove the node from the chart's redux state


### PR DESCRIPTION
Follow-up to #1376, which added `Status.Locked` and detects it at startup via the LND `State` RPC. Now that it has merged, this is rebased onto master and the diff is just the three commits below.

Three gaps that follow from `Locked` becoming a state a node can sit in indefinitely.

### `NON_EXISTING` detection was timing-based

`waitUntilOnline` treated `NON_EXISTING` as "the user must create a wallet" after two consecutive reads. Those reads are the `t=0` attempt and the first `t=3s` poll, so the entire safeguard was a 3 second window. A node started with `--noseedbackup` whose wallet auto-creation straddled that window was wrongly marked `Locked` — and `Locked` is terminal, so the user had to stop and restart the node.

The signal is deterministic and was already available: the node's effective docker command either contains `--noseedbackup` or it doesn't. Resolved the same way `composeFile.ts` does, via `getDefaultCommand`. Without the flag, abort on the first `NON_EXISTING` read; with it, keep polling until the normal 120s timeout, since LND creates the wallet itself.

### An unhandled `AbortWaitError` skipped chart cleanup

`removeBitcoinNode` awaits `waitUntilOnline` for every lightning node with no catch. A locked node now rejects that immediately, so the thunk threw before `designer.removeNode()` and `syncChart()` ran — the bitcoin node was gone from network state and from disk, but still drawn on the chart.

Now swallows `AbortWaitError` per node and rethrows anything else, so genuine startup failures keep their current behaviour.

### Rename modal didn't warn for locked nodes

`renameNode` already treats `Locked` as "was started" and restarts the network, but the modal only warned about that for `Started`. Reuses the existing i18n key, no new strings.

## Testing

- `lndService.spec.ts` — the two timing-based cases are replaced: a node on the default command keeps polling through repeated `NON_EXISTING` and resolves once state reaches `RPC_ACTIVE`; a node whose command omits the flag aborts on the first read with `getInfo` never called.
- `network.spec.ts` — `removeBitcoinNode` with a locked LN node completes and clears the chart; a non-abort failure still propagates.
- `RenameNodeModal.spec.tsx` — the restart alert renders for `Locked`.

```
yarn lint:all                                   pass
lndService · models/network · RenameNodeModal · utils/network
Test Suites: 4 passed    Tests: 197 passed
```

Unlock/init UI remains out of scope here — that's #1384.
